### PR TITLE
Fixed the video transperency controls in the media import tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ascii-motion",
   "private": true,
-  "version": "0.2.60",
+  "version": "0.2.61",
   "type": "module",
   "workspaces": [
     "packages/*",

--- a/src/components/features/MediaImportPanel.tsx
+++ b/src/components/features/MediaImportPanel.tsx
@@ -9,7 +9,7 @@
  * - Processing progress display
  */
 
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -79,13 +79,21 @@ import { ColorMatcher } from '../../utils/asciiConverter';
 
 /**
  * Apply color keying to filter out cells matching the alpha key color
+ * Uses ORIGINAL pixel colors from the source image (before preprocessing/palette mapping)
  * Returns a new Map with transparent cells removed
+ * 
+ * @param cells - The converted ASCII cells
+ * @param enableColorAsAlpha - Whether color keying is enabled
+ * @param colorAsAlphaKey - The hex color to match for transparency
+ * @param colorAsAlphaTolerance - RGB distance tolerance (0-255)
+ * @param originalImageData - The original source image data (before processing)
  */
 function applyColorKey(
   cells: Map<string, Cell>,
   enableColorAsAlpha: boolean,
   colorAsAlphaKey: string,
-  colorAsAlphaTolerance: number
+  colorAsAlphaTolerance: number,
+  originalImageData?: ImageData
 ): Map<string, Cell> {
   if (!enableColorAsAlpha) {
     return cells;
@@ -94,22 +102,41 @@ function applyColorKey(
   const filteredCells = new Map<string, Cell>();
   
   cells.forEach((cell, key) => {
-    // Check both background and text color against the alpha key
-    const bgMatches = cell.bgColor !== 'transparent' && 
-      ColorMatcher.matchesColorKey(
-        ...hexToRgb(cell.bgColor),
+    // Parse cell coordinates from key (format: "x,y")
+    const [x, y] = key.split(',').map(Number);
+    
+    let shouldRemove = false;
+    
+    if (originalImageData) {
+      // Use ORIGINAL pixel color from source image (before any processing)
+      // This is what the user sees in the transparency preview
+      const pixelIndex = (y * originalImageData.width + x) * 4;
+      const r = originalImageData.data[pixelIndex];
+      const g = originalImageData.data[pixelIndex + 1];
+      const b = originalImageData.data[pixelIndex + 2];
+      
+      // Check if this original pixel matches the color key
+      shouldRemove = ColorMatcher.matchesColorKey(r, g, b, colorAsAlphaKey, colorAsAlphaTolerance);
+    } else {
+      // Fallback: check post-processed cell colors (legacy behavior)
+      const bgMatches = cell.bgColor !== 'transparent' && 
+        ColorMatcher.matchesColorKey(
+          ...hexToRgb(cell.bgColor),
+          colorAsAlphaKey,
+          colorAsAlphaTolerance
+        );
+      
+      const textMatches = ColorMatcher.matchesColorKey(
+        ...hexToRgb(cell.color),
         colorAsAlphaKey,
         colorAsAlphaTolerance
       );
+      
+      shouldRemove = bgMatches || textMatches;
+    }
     
-    const textMatches = ColorMatcher.matchesColorKey(
-      ...hexToRgb(cell.color),
-      colorAsAlphaKey,
-      colorAsAlphaTolerance
-    );
-    
-    // Remove cell if either color matches the alpha key
-    if (!bgMatches && !textMatches) {
+    // Keep cell if it doesn't match the alpha key
+    if (!shouldRemove) {
       filteredCells.set(key, cell);
     }
   });
@@ -205,10 +232,6 @@ export function MediaImportPanel() {
   // Preview state management
   const [isPreviewActive, setIsPreviewActive] = useState(false);
   
-  // Eyedropper mode for alpha key color sampling
-  const [isEyedropperMode, setIsEyedropperMode] = useState(false);
-  const eyedropperCanvasRef = useRef<HTMLCanvasElement>(null);
-  
   // Local state for width/height inputs to allow temporary empty values
   const [widthInputValue, setWidthInputValue] = useState<string>(String(settings.characterWidth));
   const [heightInputValue, setHeightInputValue] = useState<string>(String(settings.characterHeight));
@@ -291,74 +314,6 @@ export function MediaImportPanel() {
       handleHeightChange(numValue);
     }
   }, [heightInputValue, settings.characterHeight, handleHeightChange]);
-
-  // Eyedropper mode handlers
-  const handleEyedropperClick = useCallback(() => {
-    setIsEyedropperMode(true);
-  }, []);
-  
-  const handleCanvasClick = useCallback((event: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!isEyedropperMode || previewFrames.length === 0) return;
-    
-    // Sample color from the preview frame at click position
-    const canvas = event.currentTarget;
-    const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    
-    // Scale click position to canvas coordinates
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const canvasX = Math.floor(x * scaleX);
-    const canvasY = Math.floor(y * scaleY);
-    
-    // Get the pixel from the current preview frame
-    const frame = previewFrames[frameIndex];
-    if (frame && frame.imageData) {
-      const index = (canvasY * frame.imageData.width + canvasX) * 4;
-      const r = frame.imageData.data[index];
-      const g = frame.imageData.data[index + 1];
-      const b = frame.imageData.data[index + 2];
-      
-      const hexColor = ColorMatcher.rgbToHex(r, g, b);
-      updateSettings({ colorAsAlphaKey: hexColor });
-      setLivePreviewEnabled(true); // Trigger preview update
-    }
-    
-    setIsEyedropperMode(false);
-  }, [isEyedropperMode, previewFrames, frameIndex, updateSettings, setLivePreviewEnabled]);
-
-  // Draw preview image to eyedropper canvas when eyedropper mode is active
-  useEffect(() => {
-    if (isEyedropperMode && eyedropperCanvasRef.current && previewFrames.length > 0) {
-      const canvas = eyedropperCanvasRef.current;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-
-      const frame = previewFrames[frameIndex];
-      
-      // Set canvas size to match frame
-      canvas.width = frame.imageData.width;
-      canvas.height = frame.imageData.height;
-      
-      // Draw the image data
-      ctx.putImageData(frame.imageData, 0, 0);
-    }
-  }, [isEyedropperMode, previewFrames, frameIndex]);
-
-  // Handle ESC key to exit eyedropper mode
-  useEffect(() => {
-    if (!isEyedropperMode) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsEyedropperMode(false);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isEyedropperMode]);
 
   // Preview management functions
   const startPreview = useCallback(() => {
@@ -631,11 +586,13 @@ export function MediaImportPanel() {
         const result = asciiConverter.convertFrame(previewFrames[frameIndex], conversionSettings);
         
         // Apply color keying to remove transparent cells
+        // Use original imageData to match colors before any preprocessing
         const filteredCells = applyColorKey(
           result.cells,
           settings.enableColorAsAlpha,
           settings.colorAsAlphaKey,
-          settings.colorAsAlphaTolerance
+          settings.colorAsAlphaTolerance,
+          previewFrames[frameIndex].imageData
         );
         
         // Show preview on canvas overlay (positioned based on alignment)
@@ -868,11 +825,13 @@ export function MediaImportPanel() {
         const result = asciiConverter.convertFrame(previewFrames[0], conversionSettings);
         
         // Apply color keying to remove transparent cells
+        // Use original imageData to match colors before any preprocessing
         const filteredCells = applyColorKey(
           result.cells,
           settings.enableColorAsAlpha,
           settings.colorAsAlphaKey,
-          settings.colorAsAlphaTolerance
+          settings.colorAsAlphaTolerance,
+          previewFrames[0].imageData
         );
         
         const positionedCells = positionCellsOnCanvas(filteredCells, settings.characterWidth, settings.characterHeight);
@@ -912,11 +871,13 @@ export function MediaImportPanel() {
           const result = asciiConverter.convertFrame(previewFrames[i], conversionSettings);
           
           // Apply color keying to remove transparent cells
+          // Use original imageData to match colors before any preprocessing
           const filteredCells = applyColorKey(
             result.cells,
             settings.enableColorAsAlpha,
             settings.colorAsAlphaKey,
-            settings.colorAsAlphaTolerance
+            settings.colorAsAlphaTolerance,
+            previewFrames[i].imageData
           );
           
           const positionedCells = positionCellsOnCanvas(filteredCells, settings.characterWidth, settings.characterHeight);
@@ -1267,26 +1228,6 @@ export function MediaImportPanel() {
                         )}
                       </div>
                     )}
-                    
-                    {/* Eyedropper Canvas - shows source image for color sampling */}
-                    {isEyedropperMode && previewFrames.length > 0 && (
-                      <div className="p-2 bg-primary/10 border-2 border-primary rounded-lg">
-                        <div className="text-xs text-center mb-2 font-medium text-primary">
-                          Click on the image to sample a color
-                        </div>
-                        <div className="relative flex items-center justify-center bg-black/50 rounded overflow-hidden">
-                          <canvas
-                            ref={eyedropperCanvasRef}
-                            onClick={handleCanvasClick}
-                            className="max-w-full h-auto cursor-crosshair"
-                            style={{ imageRendering: 'pixelated' }}
-                          />
-                        </div>
-                        <div className="text-xs text-center mt-2 text-muted-foreground">
-                          Press ESC or click outside to cancel
-                        </div>
-                      </div>
-                    )}
                   </div>
                 </CollapsibleContent>
               </Collapsible>
@@ -1587,7 +1528,8 @@ export function MediaImportPanel() {
               <PanelSeparator marginX="3" side="right" />
               <TransparencySection 
                 onSettingsChange={() => setLivePreviewEnabled(true)} 
-                onEyedropperClick={handleEyedropperClick}
+                previewFrames={previewFrames}
+                frameIndex={frameIndex}
               />
               
               <PanelSeparator marginX="3" side="right" />

--- a/src/components/features/TransparencySection.tsx
+++ b/src/components/features/TransparencySection.tsx
@@ -4,11 +4,12 @@
  * Features:
  * - Enable/disable color as alpha
  * - Color picker for selecting the alpha key color
- * - Eyedropper tool to sample colors from the preview
+ * - Eyedropper tool to sample colors from the preview (integrated canvas)
  * - Tolerance slider for fuzzy color matching
+ * - Visual preview showing which pixels will be transparent (green overlay)
  */
 
-import { useState } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Card, CardContent } from '../ui/card';
@@ -23,15 +24,24 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/
 import { Sparkles, ChevronDown, Pipette } from 'lucide-react';
 import { useImportSettings } from '../../stores/importStore';
 import { ColorPickerOverlay } from './ColorPickerOverlay';
+import { ColorMatcher } from '../../utils/asciiConverter';
+import type { ProcessedFrame } from '../../utils/mediaProcessor';
 
 interface TransparencySectionProps {
   onSettingsChange?: () => void;
-  onEyedropperClick?: () => void;
+  /** Preview frames from the media processor - used for eyedropper and transparency preview */
+  previewFrames?: ProcessedFrame[];
+  /** Current frame index for multi-frame media */
+  frameIndex?: number;
 }
 
-export function TransparencySection({ onSettingsChange, onEyedropperClick }: TransparencySectionProps) {
+export function TransparencySection({ onSettingsChange, previewFrames = [], frameIndex = 0 }: TransparencySectionProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const [isEyedropperActive, setIsEyedropperActive] = useState(false);
+  
+  // Canvas ref for transparency preview
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null);
   
   // Import settings
   const { settings, updateSettings } = useImportSettings();
@@ -46,10 +56,10 @@ export function TransparencySection({ onSettingsChange, onEyedropperClick }: Tra
     onSettingsChange?.();
   };
 
-  const handleColorChange = (color: string) => {
+  const handleColorChange = useCallback((color: string) => {
     updateSettings({ colorAsAlphaKey: color });
     onSettingsChange?.();
-  };
+  }, [updateSettings, onSettingsChange]);
 
   const handleToleranceChange = (value: number) => {
     updateSettings({ colorAsAlphaTolerance: value });
@@ -64,6 +74,118 @@ export function TransparencySection({ onSettingsChange, onEyedropperClick }: Tra
     handleColorChange(color);
     setIsColorPickerOpen(false);
   };
+  
+  // Handle eyedropper click on the preview canvas
+  const handleCanvasClick = useCallback((event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (previewFrames.length === 0) return;
+    
+    const canvas = event.currentTarget;
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    
+    // Scale click position to canvas coordinates
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const canvasX = Math.floor(x * scaleX);
+    const canvasY = Math.floor(y * scaleY);
+    
+    // Get the pixel from the current preview frame
+    const frame = previewFrames[frameIndex];
+    if (frame && frame.imageData) {
+      const index = (canvasY * frame.imageData.width + canvasX) * 4;
+      const r = frame.imageData.data[index];
+      const g = frame.imageData.data[index + 1];
+      const b = frame.imageData.data[index + 2];
+      
+      const hexColor = ColorMatcher.rgbToHex(r, g, b);
+      handleColorChange(hexColor);
+    }
+    
+    setIsEyedropperActive(false);
+  }, [previewFrames, frameIndex, handleColorChange]);
+  
+  // Draw the preview canvas with green overlay for matched pixels
+  useEffect(() => {
+    if (!previewCanvasRef.current || previewFrames.length === 0 || !isOpen) return;
+    
+    const canvas = previewCanvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    
+    const frame = previewFrames[frameIndex];
+    if (!frame || !frame.imageData) return;
+    
+    // Character aspect ratio - characters are 0.6x as wide as they are tall
+    // This means each "pixel" in the ASCII grid is taller than it is wide
+    // To display the preview correctly matching the original video aspect ratio,
+    // we need to make pixels taller than wide (stretch height, not width)
+    
+    const charWidth = frame.imageData.width;
+    const charHeight = frame.imageData.height;
+    
+    // Set canvas display size to show correct aspect ratio
+    // Each pixel should appear taller than wide (1:1.67 ratio, or height = width / 0.6)
+    canvas.width = charWidth;
+    canvas.height = Math.round(charHeight / 0.6);
+    
+    // Create a copy of the image data to modify
+    const displayData = new ImageData(
+      new Uint8ClampedArray(frame.imageData.data),
+      frame.imageData.width,
+      frame.imageData.height
+    );
+    
+    // If color keying is enabled, overlay green on matched pixels
+    if (enableColorAsAlpha) {
+      for (let i = 0; i < displayData.data.length; i += 4) {
+        const r = displayData.data[i];
+        const g = displayData.data[i + 1];
+        const b = displayData.data[i + 2];
+        
+        // Check if this pixel matches the color key within tolerance
+        const matches = ColorMatcher.matchesColorKey(r, g, b, colorAsAlphaKey, colorAsAlphaTolerance);
+        
+        if (matches) {
+          // Overlay bright green to show matched pixels
+          displayData.data[i] = 0;       // R
+          displayData.data[i + 1] = 255; // G
+          displayData.data[i + 2] = 0;   // B
+          // Keep alpha as-is
+        }
+      }
+    }
+    
+    // Draw the modified image data scaled to fit the aspect-ratio-corrected canvas
+    // First put original data on a temp canvas, then draw scaled
+    const tempCanvas = document.createElement('canvas');
+    tempCanvas.width = frame.imageData.width;
+    tempCanvas.height = frame.imageData.height;
+    const tempCtx = tempCanvas.getContext('2d');
+    if (tempCtx) {
+      tempCtx.putImageData(displayData, 0, 0);
+      // Draw scaled to fit the aspect-corrected canvas
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(tempCanvas, 0, 0, canvas.width, canvas.height);
+    }
+    
+  }, [previewFrames, frameIndex, isOpen, enableColorAsAlpha, colorAsAlphaKey, colorAsAlphaTolerance]);
+  
+  // Handle ESC key to exit eyedropper mode
+  useEffect(() => {
+    if (!isEyedropperActive) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsEyedropperActive(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isEyedropperActive]);
+  
+  const hasPreviewFrame = previewFrames.length > 0 && previewFrames[frameIndex]?.imageData;
 
   return (
     <>
@@ -103,42 +225,74 @@ export function TransparencySection({ onSettingsChange, onEyedropperClick }: Tra
             {enableColorAsAlpha && (
               <Card className="bg-card/30 border-border/50">
                 <CardContent className="p-3 space-y-3">
+                  {/* Source Preview Canvas - Click to sample color */}
+                  {hasPreviewFrame && (
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <Label className="text-xs font-medium">Source Preview</Label>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant={isEyedropperActive ? "default" : "outline"}
+                                size="sm"
+                                onClick={() => setIsEyedropperActive(!isEyedropperActive)}
+                                className="h-6 px-2 gap-1"
+                              >
+                                <Pipette className="h-3 w-3" />
+                                <span className="text-xs">Pick</span>
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>{isEyedropperActive ? 'Click image to sample color' : 'Enable color sampling'}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                      <div 
+                        className={`relative w-full bg-black/50 rounded overflow-hidden border-2 ${
+                          isEyedropperActive ? 'border-primary' : 'border-transparent'
+                        }`}
+                      >
+                        <canvas
+                          ref={previewCanvasRef}
+                          onClick={handleCanvasClick}
+                          className={`w-full h-auto block ${isEyedropperActive ? 'cursor-crosshair' : 'cursor-pointer'}`}
+                          style={{ imageRendering: 'pixelated' }}
+                        />
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {isEyedropperActive 
+                          ? 'Click to sample a color. Green pixels will be transparent.'
+                          : 'Green areas show pixels that will be transparent. Click "Pick" to sample a color.'}
+                      </p>
+                    </div>
+                  )}
+                  
+                  {!hasPreviewFrame && (
+                    <div className="p-3 border border-border/50 rounded-lg bg-muted/20">
+                      <p className="text-xs text-muted-foreground text-center">
+                        Process a file to see the transparency preview
+                      </p>
+                    </div>
+                  )}
+                  
                   {/* Color Selection */}
                   <div className="space-y-2">
                     <Label className="text-xs font-medium">Alpha Key Color</Label>
-                    <div className="flex gap-2">
-                      <Button
-                        variant="outline"
-                        onClick={handleColorPickerOpen}
-                        className="flex-1 h-8 justify-start gap-2 px-2"
-                      >
-                        <div 
-                          className="w-4 h-4 rounded border border-border"
-                          style={{ backgroundColor: colorAsAlphaKey }}
-                        />
-                        <span className="text-xs font-mono">{colorAsAlphaKey}</span>
-                      </Button>
-                      
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={onEyedropperClick}
-                              className="h-8 w-8 p-0"
-                            >
-                              <Pipette className="h-3 w-3" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Pick color from preview</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
+                    <Button
+                      variant="outline"
+                      onClick={handleColorPickerOpen}
+                      className="w-full h-8 justify-start gap-2 px-2"
+                    >
+                      <div 
+                        className="w-4 h-4 rounded border border-border"
+                        style={{ backgroundColor: colorAsAlphaKey }}
+                      />
+                      <span className="text-xs font-mono">{colorAsAlphaKey}</span>
+                    </Button>
                     <p className="text-xs text-muted-foreground">
-                      Cells matching this color will be transparent
+                      Pixels matching this color will be transparent in the output
                     </p>
                   </div>
 

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,12 +1,24 @@
 // Auto-generated version file - DO NOT EDIT MANUALLY
 // This file is updated by scripts/version-bump.js during deployment
 
-export const VERSION = "0.2.60";
-export const BUILD_DATE = "2026-01-25T02:12:59.070Z";
-export const BUILD_HASH = "e3d2222";
+export const VERSION = "0.2.61";
+export const BUILD_DATE = "2026-01-25T23:27:13.331Z";
+export const BUILD_HASH = "57a0e99";
 
 // Version history with commit messages
 export const VERSION_HISTORY = [
+  {
+    "version": "0.2.61",
+    "date": "2026-01-25T23:27:13.331Z",
+    "commits": [
+      "Fixed cross frame selection persistance issues",
+      "Fixed selection and shape drawing tool conflict",
+      "Fine tuned new selection tool system",
+      "Initial persistent selection added",
+      "Added implementaiton plan",
+      "Update packages"
+    ]
+  },
   {
     "version": "0.2.60",
     "date": "2026-01-25T02:12:59.070Z",


### PR DESCRIPTION
The transparency feature that keyed out user selected colors from imported videos and stills had been buggy, and I cleaned them up so they work as intended. Main changes:

1) Color key applied BEFORE the pre-processing effects, so you can use original colors for keying. 
2) Preview window for color picking in transparency section for better UX
3) Live preview of keying values with chroma green
4) Accurate pixel representation of video, rather than squeezed. 