### PR TITLE
Potential fix for code scanning alert no. 2: Insecure randomness

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -236,7 +236,38 @@ export class MCPClient {
   // ==========================================================================
 
   private generateSessionId(): string {
-    return `browser-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+    const timestamp = Date.now();
+
+    // Prefer Web Crypto API in browser-like environments
+    let randomPart: string | null = null;
+    const globalAny: any = (typeof globalThis !== 'undefined') ? (globalThis as any) : null;
+
+    const webCrypto = globalAny && (globalAny.crypto || (globalAny.window && globalAny.window.crypto));
+    if (webCrypto && typeof webCrypto.getRandomValues === 'function') {
+      const bytes = new Uint8Array(8);
+      webCrypto.getRandomValues(bytes);
+      // Convert bytes to hex string
+      randomPart = Array.from(bytes)
+        .map((b: number) => b.toString(16).padStart(2, '0'))
+        .join('')
+        .substring(0, 12);
+    } else if (typeof require === 'function') {
+      // Fallback for Node.js environments without Web Crypto
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const nodeCrypto = require('crypto');
+        const bytes: Buffer = nodeCrypto.randomBytes(8);
+        randomPart = bytes.toString('hex').substring(0, 12);
+      } catch {
+        // As a last resort, fall back to Math.random (should be rare)
+        randomPart = Math.random().toString(36).substring(2, 14);
+      }
+    } else {
+      // As a last resort, fall back to Math.random (should be rare)
+      randomPart = Math.random().toString(36).substring(2, 14);
+    }
+
+    return `browser-${timestamp}-${randomPart}`;
   }
 
   private sendAuth(): void {


### PR DESCRIPTION
Potential fix for [https://github.com/CameronFoxly/Ascii-Motion/security/code-scanning/2](https://github.com/CameronFoxly/Ascii-Motion/security/code-scanning/2)

In general, to fix insecure randomness, replace `Math.random()` with a cryptographically secure random generator wherever the value participates in any security context (IDs, tokens, secrets). For browser/Node hybrid TypeScript, `crypto.randomUUID()` (when available) or `crypto.getRandomValues()` are appropriate.

For this specific code, the minimal, non‑breaking change is to update `generateSessionId()` in `src/mcp/client.ts` to use a cryptographically strong source instead of `Math.random()`. The function currently builds `browser-<timestamp>-<random-suffix>`; we can keep this format but generate the random component using `crypto.getRandomValues` (available in modern browsers) and a small helper to convert bytes to a base‑36 string. To maintain compatibility with environments that may not expose `crypto`, we can include a guarded fallback, but since CodeQL’s concern is security, the primary path should use `crypto.getRandomValues`.

Concretely:
- Modify `generateSessionId()` (around line 238–240) to:
  - Obtain 8 random bytes via `crypto.getRandomValues(new Uint8Array(8))` (browser) or `require('crypto').randomBytes(8)` (Node, if `window.crypto` is unavailable).
  - Convert those bytes to a hex string and then to a base‑36 substring (or just use hex directly) and interpolate into the session ID string.
- No other parts of the file need to change; callers continue to use `this.generateSessionId()` as before.
- No new third‑party libraries are required; only the built‑in `crypto` APIs are used. We can reference `window.crypto`/`self.crypto` without adding imports, and conditionally require Node’s `crypto` only if needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
