### PR TITLE
Change video export default to 1x and auto-init submodules on dev

### DIFF
--- a/src/components/features/VideoExportDialog.tsx
+++ b/src/components/features/VideoExportDialog.tsx
@@ -31,7 +31,7 @@ export const VideoExportDialog: React.FC = () => {
   const projectName = useProjectMetadataStore((state) => state.projectName);
   
   const [videoSettings, setVideoSettings] = useState<VideoExportSettings>({
-    sizeMultiplier: 2,
+    sizeMultiplier: 1,
     frameRate: 'auto',
     frameRange: 'all',
     quality: 'high',


### PR DESCRIPTION
## Why

Two small DX improvements:

1. **Video export defaulted to 2x resolution**, which is unnecessarily large for most use cases. The image export and the export store both already default to 1x — this aligns the video export dialog to match.

## Changes

- **`VideoExportDialog.tsx`** — Default `sizeMultiplier` changed from `2` to `1` in the component's local state initializer.