### PR TITLE
Add taper controls to rectangle and ellipse tool settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ascii-motion",
-  "version": "2.0.15",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ascii-motion",
-      "version": "2.0.15",
+      "version": "2.1.0",
       "workspaces": [
         "packages/*",
         "packages/web/marketing",

--- a/src/components/features/ToolPalette.tsx
+++ b/src/components/features/ToolPalette.tsx
@@ -355,11 +355,18 @@ export const ToolOptionsPanel = React.memo(({ activeTool }: { activeTool: Tool }
           </div>
           )}
           {(!shapeFilled || fillMode === 'lineart') && (
-            <div className="flex items-center gap-1">
-              <Label className="text-[10px] text-muted-foreground">Width:</Label>
-              <Slider min={0.1} max={10} step={0.1} value={strokeWidth} onValueChange={setStrokeWidth} className="w-16" />
-              <span className="text-[10px] text-muted-foreground tabular-nums w-6">{strokeWidth.toFixed(1)}</span>
-            </div>
+            <>
+              <div className="flex items-center gap-1">
+                <Label className="text-[10px] text-muted-foreground">Width:</Label>
+                <Slider min={0.1} max={10} step={0.1} value={strokeWidth} onValueChange={setStrokeWidth} className="w-16" />
+                <span className="text-[10px] text-muted-foreground tabular-nums w-6">{strokeWidth.toFixed(1)}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Label className="text-[10px] text-muted-foreground">Taper:</Label>
+                <Slider min={0} max={1} step={0.01} value={strokeTaperStart} onValueChange={setStrokeTaperStart} className="w-12" />
+                <Slider min={0} max={1} step={0.01} value={strokeTaperEnd} onValueChange={setStrokeTaperEnd} className="w-12" />
+              </div>
+            </>
           )}
         </>
       )}


### PR DESCRIPTION
## Problem

When a user sets stroke width and taper settings with the bezier/pen tool, then switches to the rectangle or ellipse tool, the taper values persist and affect shape rendering — but the UI controls for changing those values are **not visible** in the rect/ellipse tool settings bar. This means the user can't modify or remove taper values when using shape tools.

## Root Cause

All three tools (pen, rectangle, ellipse) share the same bezier store (`strokeTaperStart`, `strokeTaperEnd`), and the `InteractiveVectorShapeOverlay` passes these taper values through when rendering shapes. However, the `ToolOptionsPanel` in `ToolPalette.tsx` only rendered the Taper slider controls for the `beziershape` tool — the `rectangle`/`ellipse` section only had the Width slider.

## Fix

Added the Taper start/end slider controls to the rectangle and ellipse tool settings section (alongside the existing Width slider), matching the pen tool's UI. The controls appear when the stroke is visible (`!shapeFilled || fillMode === 'lineart'`), consistent with the Width control.

Fixes #109