### PR TITLE
fix: auto-apply ASCII box work when switching tools instead of discarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ascii-motion",
-  "version": "2.0.15",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ascii-motion",
-      "version": "2.0.15",
+      "version": "2.1.0",
       "workspaces": [
         "packages/*",
         "packages/web/marketing",

--- a/src/hooks/useAsciiBoxTool.ts
+++ b/src/hooks/useAsciiBoxTool.ts
@@ -79,10 +79,40 @@ export const useAsciiBoxTool = () => {
     }
   }, [activeTool, isPanelOpen, openPanel]);
   
-  // Cancel preview and close panel when switching away from ASCII Box tool
+  // Auto-apply preview and close panel when switching away from ASCII Box tool
   useEffect(() => {
     if (activeTool !== 'asciibox' && isPanelOpen) {
-      // User switched tools - cancel preview (if any) and close panel
+      // User switched tools - auto-apply any pending work so it isn't lost
+      const boxState = useAsciiBoxStore.getState();
+
+      if (boxState.isApplying && boxState.previewData && boxState.previewData.size > 0) {
+        const canvasState = useCanvasStore.getState();
+        const currentCells = canvasState.cells;
+        const originalCells = new Map(currentCells);
+
+        const transformedPreview = transformCellMapToLocal(boxState.previewData);
+        const newCells = new Map(currentCells);
+        transformedPreview.forEach((cell, key) => {
+          newCells.set(key, { ...cell });
+        });
+
+        canvasState.setCanvasData(newCells);
+
+        // Push to undo history so the user can revert if they intended to cancel
+        const historyAction: CanvasHistoryAction = {
+          type: 'canvas_edit',
+          timestamp: Date.now(),
+          description: `ASCII Box Drawing (auto-applied on tool switch)`,
+          data: {
+            previousCanvasData: originalCells,
+            newCanvasData: newCells,
+            frameIndex: useTimelineStore.getState().view.currentFrame
+          }
+        };
+
+        useToolStore.getState().pushToHistory(historyAction);
+      }
+
       reset();
       closePanel();
     }


### PR DESCRIPTION
## Summary

Fixes #110 — When users switch away from the ASCII box tool without clicking "Apply", their work was silently discarded. This was bad UX with no way to recover.

## Change

Modified the tool-switch effect in `useAsciiBoxTool.ts` to **auto-apply** any pending ASCII box preview data to the canvas before resetting state. The auto-applied work is properly pushed to the undo history so users can revert with Ctrl+Z if they intended to cancel.

### Before
Switching tools → `reset()` + `closePanel()` → all box drawing work lost

### After  
Switching tools → detect pending preview → apply to canvas + push undo history → reset + close panel

## Verification
- TypeScript: compiles with zero errors
- Lint: no new warnings (2 pre-existing errors in unrelated files)
- Tests: all 379 tests pass