### PR TITLE
Fix My Projects dialog: button disabled state and timestamp bugs

### DIFF
--- a/src/components/features/ProjectsDialog.tsx
+++ b/src/components/features/ProjectsDialog.tsx
@@ -183,6 +183,7 @@ export function ProjectsDialog({
   const [editingDescriptionId, setEditingDescriptionId] = useState<string | null>(null);
   const [newDescription, setNewDescription] = useState('');
   const [uploading, setUploading] = useState(false);
+  const [openingProjectId, setOpeningProjectId] = useState<string | null>(null);
   const [trashExpanded, setTrashExpanded] = useState(false);
   const [userProfile, setUserProfile] = useState<UserProfile | null>(() => getCachedUserProfile());
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
@@ -308,6 +309,7 @@ export function ProjectsDialog({
       setNewName('');
       setEditingDescriptionId(null);
       setNewDescription('');
+      setOpeningProjectId(null);
       hasLoadedOnce.current = false;
     }
   }, [open]);
@@ -342,6 +344,7 @@ export function ProjectsDialog({
   };
 
   const handleOpenProject = async (project: CloudProject) => {
+    setOpeningProjectId(project.id);
     try {
       const cloudProject = await loadFromCloud(project.id);
       if (cloudProject) {
@@ -351,6 +354,8 @@ export function ProjectsDialog({
       }
     } catch (err) {
       console.error('[ProjectsDialog] Load failed:', err);
+    } finally {
+      setOpeningProjectId(null);
     }
   };
 
@@ -754,10 +759,19 @@ export function ProjectsDialog({
                     <Button
                       className="w-full"
                       onClick={() => handleOpenProject(project)}
-                      disabled={loading}
+                      disabled={openingProjectId !== null}
                     >
-                      <FolderOpen className="h-4 w-4 mr-2" />
-                      Open
+                      {openingProjectId === project.id ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Opening...
+                        </>
+                      ) : (
+                        <>
+                          <FolderOpen className="h-4 w-4 mr-2" />
+                          Open
+                        </>
+                      )}
                     </Button>
                   </CardFooter>
                 </Card>


### PR DESCRIPTION
## Why

Two user-facing bugs in the My Projects dialog:

1. **Open buttons disabled during preview loading** -- All "Open" buttons stay unclickable until every project's pixel preview finishes loading, even though the per-project progressive loading was already in place.
2. **Unreliable "last opened" timestamps** -- Every project shows the same "last opened" time (e.g. "3 days ago" for all), and any interaction like renaming resets all projects to "just now".

## Root causes

Both bugs trace back to `loadProjectsSessionData` calling `loadFromCloud()` for each project to fetch preview data. `loadFromCloud` has two side effects that are correct when *opening* a project but wrong for background preview fetching:

- It sets the shared `loading` state to `true`, which the Open buttons were bound to via `disabled={loading}`.
- It writes `last_opened_at = NOW` to the database for the project, corrupting the timestamp for every project whose preview was loaded.

## Approach

**Premium submodule (`useCloudProject.ts`):**
- Added `loadProjectDataOnly()` -- a read-only fetch that retrieves canvas data without updating `last_opened_at` or toggling the shared `loading` state.
- Changed `loadProjectsSessionData` to use `loadProjectDataOnly` instead of `loadFromCloud`.

**Main app (`ProjectsDialog.tsx`):**
- Replaced `disabled={loading}` on Open buttons with a local `openingProjectId` state.
- Buttons are now clickable immediately after the project list renders.
- The specific project being opened shows a spinner ("Opening...") while all buttons are temporarily disabled during that single operation.
- Reset `openingProjectId` on dialog close for clean state.

## Testing notes

- Open the My Projects dialog -- all Open buttons should be clickable right away, even while previews are still loading in.
- Verify "Last opened" timestamps are distinct per project and match actual open history.
- Rename or edit a description -- other projects' timestamps should not change.