### PR TITLE
Fix typography menu alignment and font detection accuracy

### DIFF
--- a/src/components/features/CanvasSettings.tsx
+++ b/src/components/features/CanvasSettings.tsx
@@ -245,15 +245,16 @@ export const CanvasSettings: React.FC = () => {
     }
   }, []);
 
-  // Calculate dropdown position
+  // Calculate dropdown position (right-aligned with the button)
   const calculatePosition = (buttonRef: HTMLDivElement | null) => {
     if (!buttonRef) return { top: 0, left: 0, width: 280 };
     
+    const dropdownWidth = 280;
     const rect = buttonRef.getBoundingClientRect();
     return {
       top: rect.bottom + 4,
-      left: rect.left,
-      width: 280  // Fixed width for typography dropdown
+      left: rect.right - dropdownWidth,
+      width: dropdownWidth
     };
   };
 

--- a/src/constants/fonts.ts
+++ b/src/constants/fonts.ts
@@ -35,6 +35,15 @@ export const MONOSPACE_FONTS: MonospaceFont[] = [
     description: 'Classic macOS monospace - crisp and readable'
   },
   {
+    id: 'menlo',
+    name: 'Menlo',
+    displayName: 'Menlo (macOS)',
+    cssStack: 'Menlo, monospace',
+    category: 'system',
+    platforms: ['macos'],
+    description: 'macOS default monospace - clean and highly readable'
+  },
+  {
     id: 'consolas',
     name: 'Consolas',
     displayName: 'Consolas (Windows)',

--- a/src/constants/fonts.ts
+++ b/src/constants/fonts.ts
@@ -107,7 +107,7 @@ export const MONOSPACE_FONTS: MonospaceFont[] = [
     cssStack: 'Px437 IBM VGA 9x14, monospace',
     category: 'web',
     description: 'Classic IBM VGA font - authentic retro terminal aesthetic',
-    isBundled: false,
+    isBundled: true,
     fileSize: '~25KB'
   },
   {
@@ -117,7 +117,7 @@ export const MONOSPACE_FONTS: MonospaceFont[] = [
     cssStack: 'Px437 IBM DOS ISO8, monospace',
     category: 'web',
     description: 'Classic IBM DOS font with ISO-8859-1 extended characters',
-    isBundled: false,
+    isBundled: true,
     fileSize: '~28KB'
   },
   {
@@ -127,7 +127,7 @@ export const MONOSPACE_FONTS: MonospaceFont[] = [
     cssStack: '"C64 Pro", monospace',
     category: 'web',
     description: 'Commodore 64 font - proportional variant for different rendering',
-    isBundled: false,
+    isBundled: true,
     fileSize: '~30KB'
   },
   {

--- a/src/utils/fontDetection.ts
+++ b/src/utils/fontDetection.ts
@@ -1,7 +1,8 @@
 /**
  * Font Detection Utility
  * Detects which fonts are actually available on the user's system
- * Uses canvas text measurement technique to determine font availability
+ * Uses FontFace local() probing as the primary detection method,
+ * with canvas measurement as a fallback for older browsers.
  */
 
 import { isFontLoaded as isBundledFontLoaded } from '@/utils/fontLoader';
@@ -14,45 +15,38 @@ const detectedFontCache = new Map<string, string>();
 const actualUsedFontCache = new Map<string, string>();
 
 /**
- * Check if a specific font is available on the system
- * Uses canvas measurement with serif AND sans-serif baselines for better accuracy
+ * Probe whether a font is installed locally using the FontFace API.
+ * Creates a temporary FontFace with a local() source and attempts to load it.
+ * Resolves true if the font is found, false otherwise.
  */
-export async function isFontAvailable(fontName: string): Promise<boolean> {
-  // Check cache first
-  if (fontAvailabilityCache.has(fontName)) {
-    return fontAvailabilityCache.get(fontName)!;
-  }
+async function probeLocalFont(fontName: string): Promise<boolean> {
+  if (typeof FontFace === 'undefined') return false;
 
-  // For fonts we explicitly loaded via @font-face, document.fonts.check() is reliable.
-  // For system fonts it gives false positives (returns true even when the font isn't
-  // installed, because the browser can render with a fallback without downloading).
-  if (isBundledFontLoaded(fontName) && document.fonts) {
-    try {
-      const fontWithQuotes = fontName.includes(' ') ? `"${fontName}"` : fontName;
-      const isAvailableViaCSS = document.fonts.check(`12px ${fontWithQuotes}`);
-      if (isAvailableViaCSS) {
-        fontAvailabilityCache.set(fontName, true);
-        return true;
-      }
-    } catch {
-      // If check() throws, fall through to canvas measurement
-    }
-  }
-
-  const canvas = document.createElement('canvas');
-  const context = canvas.getContext('2d');
-  
-  if (!context) {
-    fontAvailabilityCache.set(fontName, false);
+  try {
+    const face = new FontFace('__probe__', `local("${fontName}")`);
+    await face.load();
+    return true;
+  } catch {
     return false;
   }
+}
 
-  // Use multiple test strings and baseline fonts
-  const testStrings = ['mmmmmmmmmmlli', 'iIl1O0'];
+/**
+ * Canvas-based font detection fallback.
+ * Compares glyph widths against baseline generic fonts.
+ * Less reliable than FontFace local() — fonts whose metrics match
+ * the baseline will produce false negatives.
+ */
+function canvasFontDetection(fontName: string): boolean {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+
+  if (!context) return false;
+
+  const testStrings = ['mmmmmmmmmmlli', 'iIl1O0', 'WMwm@#'];
   const baselineFonts = ['monospace', 'sans-serif', 'serif'];
   const testSize = '72px';
-  
-  // Collect baseline measurements
+
   const baselines = new Map<string, number[]>();
   for (const baselineFont of baselineFonts) {
     const widths: number[] = [];
@@ -63,33 +57,55 @@ export async function isFontAvailable(fontName: string): Promise<boolean> {
     baselines.set(baselineFont, widths);
   }
 
-  // Test the font both with and without quotes (SF Mono behaves differently)
-  const fontVariations = [
-    `"${fontName}"`,
-    fontName
-  ];
+  const fontVariations = [`"${fontName}"`, fontName];
 
   for (const fontVariation of fontVariations) {
-    // Test against each baseline
     for (const baselineFont of baselineFonts) {
       const baselineWidths = baselines.get(baselineFont)!;
-      
+
       for (let i = 0; i < testStrings.length; i++) {
-        const testString = testStrings[i];
         context.font = `${testSize} ${fontVariation}, ${baselineFont}`;
-        const testWidth = context.measureText(testString).width;
-        
-        // If this width differs from the baseline, the font is available
+        const testWidth = context.measureText(testStrings[i]).width;
+
         if (testWidth !== baselineWidths[i]) {
-          fontAvailabilityCache.set(fontName, true);
           return true;
         }
       }
     }
   }
 
-  fontAvailabilityCache.set(fontName, false);
   return false;
+}
+
+/**
+ * Check if a specific font is available on the system.
+ * Uses FontFace local() probing (most reliable), falling back to
+ * canvas measurement for environments without FontFace support.
+ */
+export async function isFontAvailable(fontName: string): Promise<boolean> {
+  // Check cache first
+  if (fontAvailabilityCache.has(fontName)) {
+    return fontAvailabilityCache.get(fontName)!;
+  }
+
+  // For bundled fonts we loaded via @font-face, trust our own loader state
+  if (isBundledFontLoaded(fontName)) {
+    fontAvailabilityCache.set(fontName, true);
+    return true;
+  }
+
+  // Primary: FontFace local() probing — directly asks the browser
+  // whether the font is installed locally
+  const localResult = await probeLocalFont(fontName);
+  if (localResult) {
+    fontAvailabilityCache.set(fontName, true);
+    return true;
+  }
+
+  // Fallback: canvas measurement (for browsers where local() is restricted)
+  const canvasResult = canvasFontDetection(fontName);
+  fontAvailabilityCache.set(fontName, canvasResult);
+  return canvasResult;
 }
 
 /**
@@ -111,8 +127,8 @@ function parseFontStack(fontStack: string): string[] {
 }
 
 /**
- * Get the actual font being used by the browser for a given font stack
- * Tests each font in order and returns the first available one
+ * Get the actual font being used by the browser for a given font stack.
+ * Tests each font in stack order and returns the first available one.
  */
 async function getActualUsedFont(fontStack: string): Promise<string> {
   // Check cache first
@@ -122,7 +138,7 @@ async function getActualUsedFont(fontStack: string): Promise<string> {
 
   const fonts = parseFontStack(fontStack);
 
-  // Test each font in order
+  // Test each font in order — the browser uses the first available one
   for (const font of fonts) {
     const isAvailable = await isFontAvailable(font);
     if (isAvailable) {
@@ -131,37 +147,11 @@ async function getActualUsedFont(fontStack: string): Promise<string> {
     }
   }
   
-  // Special case: Some fonts (like SF Mono on macOS) have identical metrics to generic monospace
-  // and can't be detected via measurement, but ARE available. Check if we should trust the first font.
-  if (fonts.length > 0 && fonts.length <= 2) { // Only for specific font selections (not auto)
-    const firstFont = fonts[0];
-    
-    // List of fonts known to have identical metrics to system defaults on certain platforms
-    const platformIdenticalFonts = [
-      { font: 'SF Mono', platform: 'mac' },
-      { font: 'SFMono-Regular', platform: 'mac' }
-    ];
-    
-    const userAgent = navigator.userAgent.toLowerCase();
-    const isMac = userAgent.includes('mac');
-    
-    // Check if this font is known to be identical to system default on this platform
-    const isKnownIdentical = platformIdenticalFonts.some(
-      item => item.font === firstFont && 
-              ((item.platform === 'mac' && isMac))
-    );
-    
-    if (isKnownIdentical) {
-      actualUsedFontCache.set(fontStack, firstFont);
-      return firstFont;
-    }
-  }
-  
-  // For "auto" mode or if detection failed, try to detect the system's default
-  
+  // If no font in the stack was detected, try common system fonts
+  // (covers the "auto" case where the stack might not list every system font)
   const commonSystemFonts = [
-    'Menlo',
     'SF Mono',
+    'Menlo',
     'Monaco', 
     'Consolas',
     'Courier New',
@@ -169,7 +159,6 @@ async function getActualUsedFont(fontStack: string): Promise<string> {
   ];
   
   for (const systemFont of commonSystemFonts) {
-    // Skip if already tested
     if (fonts.includes(systemFont)) continue;
     
     const isAvailable = await isFontAvailable(systemFont);
@@ -179,7 +168,7 @@ async function getActualUsedFont(fontStack: string): Promise<string> {
     }
   }
   
-  // Ultimate fallback - couldn't detect specific font
+  // Ultimate fallback
   actualUsedFontCache.set(fontStack, 'monospace');
   return 'monospace';
 }

--- a/src/utils/fontDetection.ts
+++ b/src/utils/fontDetection.ts
@@ -147,29 +147,56 @@ async function getActualUsedFont(fontStack: string): Promise<string> {
     }
   }
   
-  // If no font in the stack was detected, try common system fonts
-  // (covers the "auto" case where the stack might not list every system font)
-  const commonSystemFonts = [
-    'SF Mono',
-    'Menlo',
-    'Monaco', 
-    'Consolas',
-    'Courier New',
-    'Courier'
+  // No named font in the stack was available, so the browser is using
+  // the generic `monospace` fallback. Detect which concrete font that
+  // maps to by comparing canvas metrics against known candidates.
+  const resolvedMonospace = detectMonospaceDefault();
+  actualUsedFontCache.set(fontStack, resolvedMonospace);
+  return resolvedMonospace;
+}
+
+/**
+ * Detect which concrete font the browser's generic `monospace` maps to.
+ * Renders text with bare `monospace` and compares metrics against known
+ * monospace fonts to find the match.
+ */
+function detectMonospaceDefault(): string {
+  const candidates = [
+    'Menlo', 'SF Mono', 'Monaco', 'Consolas',
+    'Cascadia Code', 'Courier New', 'Courier'
   ];
-  
-  for (const systemFont of commonSystemFonts) {
-    if (fonts.includes(systemFont)) continue;
-    
-    const isAvailable = await isFontAvailable(systemFont);
-    if (isAvailable) {
-      actualUsedFontCache.set(fontStack, systemFont);
-      return systemFont;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return 'monospace';
+
+  const testStrings = ['mmmmmmmmmmlli', 'iIl1O0', 'WMwm@#'];
+  const size = '72px';
+
+  // Measure the baseline: bare `monospace`
+  const baseWidths: number[] = [];
+  for (const s of testStrings) {
+    ctx.font = `${size} monospace`;
+    baseWidths.push(ctx.measureText(s).width);
+  }
+
+  // Find the candidate whose metrics match the baseline
+  for (const candidate of candidates) {
+    let allMatch = true;
+    for (let i = 0; i < testStrings.length; i++) {
+      ctx.font = `${size} "${candidate}", monospace`;
+      if (ctx.measureText(testStrings[i]).width !== baseWidths[i]) {
+        allMatch = false;
+        break;
+      }
+    }
+    // If all test strings match, this font IS the monospace default
+    // (its metrics are identical because the browser is already using it)
+    if (allMatch) {
+      return candidate;
     }
   }
-  
-  // Ultimate fallback
-  actualUsedFontCache.set(fontStack, 'monospace');
+
   return 'monospace';
 }
 

--- a/src/utils/fontDetection.ts
+++ b/src/utils/fontDetection.ts
@@ -4,6 +4,8 @@
  * Uses canvas text measurement technique to determine font availability
  */
 
+import { isFontLoaded as isBundledFontLoaded } from '@/utils/fontLoader';
+
 // Cache font availability results to avoid repeated checks
 const fontAvailabilityCache = new Map<string, boolean>();
 const detectedFontCache = new Map<string, string>();
@@ -21,11 +23,11 @@ export async function isFontAvailable(fontName: string): Promise<boolean> {
     return fontAvailabilityCache.get(fontName)!;
   }
 
-  // First, check if the font is available via CSS Font Loading API
-  // This catches fonts loaded via @font-face declarations
-  if (document.fonts) {
+  // For fonts we explicitly loaded via @font-face, document.fonts.check() is reliable.
+  // For system fonts it gives false positives (returns true even when the font isn't
+  // installed, because the browser can render with a fallback without downloading).
+  if (isBundledFontLoaded(fontName) && document.fonts) {
     try {
-      // Try with quotes (for fonts with spaces)
       const fontWithQuotes = fontName.includes(' ') ? `"${fontName}"` : fontName;
       const isAvailableViaCSS = document.fonts.check(`12px ${fontWithQuotes}`);
       if (isAvailableViaCSS) {

--- a/src/utils/fontLoader.ts
+++ b/src/utils/fontLoader.ts
@@ -24,6 +24,15 @@ const BUNDLED_FONT_FILES: Record<string, { url: string; weight?: number; style?:
   ],
   'Geist Mono': [
     { url: '/fonts/GeistMono-Regular.woff2', weight: 400, style: 'normal' }
+  ],
+  'Px437 IBM VGA 9x14': [
+    { url: '/fonts/Px437_IBM_VGA_9x14.ttf', weight: 400, style: 'normal', format: 'truetype' }
+  ],
+  'Px437 IBM DOS ISO8': [
+    { url: '/fonts/Px437_IBM_DOS_ISO8.ttf', weight: 400, style: 'normal', format: 'truetype' }
+  ],
+  'C64 Pro': [
+    { url: '/fonts/C64_Pro-STYLE.ttf', weight: 400, style: 'normal', format: 'truetype' }
   ]
 };
 


### PR DESCRIPTION
## Why

The typography settings dropdown had two categories of issues: a layout problem where the menu opened with its right edge off-screen, and several font detection inaccuracies that showed incorrect "Using ..." labels for system fonts.

## What changed

**Menu positioning** -- The typography dropdown was left-aligned with its trigger button, pushing it off-screen. Changed to right-align the dropdown's right edge with the button's right edge.

**Bundled font labels** -- Three retro fonts (IBM VGA, IBM DOS, C64 Pro) ship their files in `public/fonts/` but were marked `isBundled: false` and missing from the font loader registry. Fixed both so they show the "Bundled" badge and load correctly.

**Font detection rewrite** -- The previous canvas-based measurement technique had multiple failure modes:
- `document.fonts.check()` returned false positives for uninstalled fonts (e.g., Cascadia Code on macOS) because it only checks whether text can render without downloads, not whether the specific font is present.
- Canvas glyph-width comparison produced false negatives for fonts whose metrics match the system monospace baseline (SF Mono, Consolas on Mac).
- The "Auto" mode incorrectly reported Monaco instead of SF Mono because a `platformIdenticalFonts` workaround only applied to font stacks with 2 or fewer entries.

Replaced primary detection with `FontFace` + `local()` probing (`new FontFace('__probe__', 'local("FontName")').load()`), which directly asks the browser whether a font is installed. Canvas measurement is retained as a fallback.

**Fallback font reporting** -- When a selected font isn't available and the browser uses the generic `monospace` fallback, the old code walked a list of installed fonts and returned the first hit (SF Mono), not what the browser actually renders (Menlo on macOS). Added `detectMonospaceDefault()` which compares canvas metrics against bare `monospace` to identify the actual default.

**Added Menlo** -- Added Menlo as a directly selectable font option since it's the default monospace font on macOS.

## Files changed

- `src/components/features/CanvasSettings.tsx` -- Right-align dropdown positioning
- `src/constants/fonts.ts` -- Mark retro fonts as bundled, add Menlo
- `src/utils/fontLoader.ts` -- Register retro font TTF files
- `src/utils/fontDetection.ts` -- Rewrite detection with FontFace local() probing and monospace default detection