### PR TITLE
feat: Image Trace overlay for tracing reference images/videos

### DIFF
--- a/src/components/features/CanvasSettings.tsx
+++ b/src/components/features/CanvasSettings.tsx
@@ -5,8 +5,9 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Grid3X3, Palette, Type, AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+import { Grid3X3, Palette, Type, AlertTriangle, CheckCircle2, Loader2, Image as ImageIcon } from 'lucide-react';
 import { CanvasResizeDialog } from './CanvasResizeDialog';
+import { ImageTraceControls } from './ImageTraceControls';
 import { ToolOptionsPanel } from './ToolPalette';
 import { useCanvasStore } from '@/stores/canvasStore';
 import { useCanvasContext } from '@/contexts/CanvasContext';
@@ -14,6 +15,7 @@ import { useToolStore } from '@/stores/toolStore';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { useProjectDialogState } from '@/hooks/useProjectDialogState';
 import { MONOSPACE_FONTS, DEFAULT_FONT_ID } from '@/constants/fonts';
+import { useImageTraceStore } from '@/stores/imageTraceStore';
 import { getFontFallbackMessage } from '@/utils/fontDetection';
 import {
   charactersToPixels,
@@ -220,14 +222,21 @@ export const CanvasSettings: React.FC = () => {
   // Replace inline dropdown picker with modal overlay reuse
   const [showColorPicker, setShowColorPicker] = useState(false);
   const [showTypographyPicker, setShowTypographyPicker] = useState(false);
+  const [showImageTracePicker, setShowImageTracePicker] = useState(false);
   // (Removed old dropdown animation state)
   const [typographyPickerAnimationClass, setTypographyPickerAnimationClass] = useState('');
+  const [imageTracePickerAnimationClass, setImageTracePickerAnimationClass] = useState('');
   // Temp color state removed; modal handles confirmation
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
+  const [imageTraceDropdownPosition, setImageTraceDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
   const colorPickerRef = useRef<HTMLDivElement>(null);
   const typographyPickerRef = useRef<HTMLDivElement>(null);
+  const imageTracePickerRef = useRef<HTMLDivElement>(null);
   const colorPickerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const typographyPickerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const imageTracePickerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const imageTraceEnabled = useImageTraceStore((s) => s.enabled);
+  const imageTraceSource = useImageTraceStore((s) => s.source);
 
   const clearColorPickerTimeout = useCallback(() => {
     const timeout = colorPickerTimeoutRef.current;
@@ -242,6 +251,14 @@ export const CanvasSettings: React.FC = () => {
     if (timeout) {
       clearTimeout(timeout);
       typographyPickerTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearImageTracePickerTimeout = useCallback(() => {
+    const timeout = imageTracePickerTimeoutRef.current;
+    if (timeout) {
+      clearTimeout(timeout);
+      imageTracePickerTimeoutRef.current = null;
     }
   }, []);
 
@@ -290,6 +307,26 @@ export const CanvasSettings: React.FC = () => {
     }, 100); // Match faster exit animation duration
   }, [showTypographyPicker]);
 
+  // Animated show/hide functions for image trace picker
+  const showImageTracePickerAnimated = useCallback(() => {
+    if (imageTracePickerTimeoutRef.current) {
+      clearTimeout(imageTracePickerTimeoutRef.current);
+    }
+    setShowImageTracePicker(true);
+    setImageTracePickerAnimationClass('dropdown-enter');
+  }, []);
+
+  const closeImageTracePicker = useCallback(() => {
+    if (!showImageTracePicker) {
+      return;
+    }
+    setImageTracePickerAnimationClass('dropdown-exit');
+    imageTracePickerTimeoutRef.current = setTimeout(() => {
+      setShowImageTracePicker(false);
+      setImageTracePickerAnimationClass('');
+    }, 100);
+  }, [showImageTracePicker]);
+
 
   // Close typography picker when clicking outside (color picker overlay handles its own dialog focus trapping)
   useEffect(() => {
@@ -314,24 +351,47 @@ export const CanvasSettings: React.FC = () => {
     }
   }, [showTypographyPicker, closeTypographyPicker]);
 
+  // Close image trace picker when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      if (showImageTracePicker && 
+          imageTracePickerRef.current && 
+          !imageTracePickerRef.current.contains(target)) {
+        const imageTraceDropdown = document.getElementById('image-trace-dropdown');
+        if (!imageTraceDropdown || !imageTraceDropdown.contains(target)) {
+          closeImageTracePicker();
+        }
+      }
+    };
+
+    if (showImageTracePicker) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [showImageTracePicker, closeImageTracePicker]);
+
   // Reset dropdown states when layout might be changing (e.g., window resize)
   useEffect(() => {
     const handleLayoutChange = () => {
       closeColorPicker();
       closeTypographyPicker();
+      closeImageTracePicker();
     };
 
     window.addEventListener('resize', handleLayoutChange);
     return () => window.removeEventListener('resize', handleLayoutChange);
-  }, [closeColorPicker, closeTypographyPicker]);
+  }, [closeColorPicker, closeTypographyPicker, closeImageTracePicker]);
 
   // Clean up timeouts on unmount
   useEffect(() => {
     return () => {
       clearColorPickerTimeout();
       clearTypographyPickerTimeout();
+      clearImageTracePickerTimeout();
     };
-  }, [clearColorPickerTimeout, clearTypographyPickerTimeout]);
+  }, [clearColorPickerTimeout, clearTypographyPickerTimeout, clearImageTracePickerTimeout]);
 
   // Handle real-time color changes (for live preview)
   const handleColorPickerChange = (color: string) => {
@@ -542,6 +602,38 @@ export const CanvasSettings: React.FC = () => {
               </TooltipContent>
             </Tooltip>
           </div>
+
+          {/* Image Trace Controls */}
+          <div className="relative" ref={imageTracePickerRef}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={imageTraceEnabled && imageTraceSource ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => {
+                    if (showImageTracePicker) {
+                      closeImageTracePicker();
+                    } else {
+                      const position = calculatePosition(imageTracePickerRef.current);
+                      setImageTraceDropdownPosition(position);
+                      closeColorPicker();
+                      closeTypographyPicker();
+                      showImageTracePickerAnimated();
+                    }
+                  }}
+                  className="h-6 w-6 p-0 leading-none flex items-center justify-center [&_svg]:w-3 [&_svg]:h-3"
+                  aria-label="Image trace"
+                  aria-expanded={showImageTracePicker}
+                  aria-controls="image-trace-dropdown"
+                >
+                  <ImageIcon className="w-3 h-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">Upload image or video to use as an overlay for tracing</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </div>
 
@@ -724,6 +816,26 @@ export const CanvasSettings: React.FC = () => {
                 </Button>
               </div>
             </div>
+          </div>,
+          document.body
+        )}
+
+        {/* Image Trace Picker Dropdown - Portal rendered for proper layering */}
+        {showImageTracePicker && imageTraceDropdownPosition.top > 0 && createPortal(
+          <div 
+            id="image-trace-dropdown"
+            className={`fixed z-[99999] p-3 bg-popover border border-border rounded-md shadow-lg ${imageTracePickerAnimationClass}`}
+            style={{
+              top: `${imageTraceDropdownPosition.top}px`,
+              left: `${imageTraceDropdownPosition.left}px`,
+              width: `${imageTraceDropdownPosition.width}px`
+            }}
+            role="menu"
+            aria-label="Image trace settings"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ImageTraceControls />
           </div>,
           document.body
         )}

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -92,6 +92,9 @@ export const ImageTraceControls: React.FC = () => {
         ? await processTraceImage(file)
         : await processTraceVideo(file);
       setSource(result);
+      // Auto fit-to-canvas on load
+      const dims = getCanvasPixelDimensions();
+      fitToCanvas(dims.width, dims.height);
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : 'Failed to load file');
     }
@@ -100,7 +103,7 @@ export const ImageTraceControls: React.FC = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  }, [setSource, clearSource, setLoading, setLoadError]);
+  }, [setSource, clearSource, setLoading, setLoadError, fitToCanvas, getCanvasPixelDimensions]);
 
   const handleFitToCanvas = useCallback(() => {
     const dims = getCanvasPixelDimensions();

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -296,7 +296,7 @@ export const ImageTraceControls: React.FC = () => {
               <div className="flex items-center gap-2">
                 <input
                   type="range"
-                  min="0"
+                  min={-(source.totalVideoFrames - 1)}
                   max={Math.max(0, source.totalVideoFrames - 1)}
                   step="1"
                   value={frameOffset}
@@ -305,7 +305,7 @@ export const ImageTraceControls: React.FC = () => {
                 />
                 <input
                   type="number"
-                  min="0"
+                  min={-(source.totalVideoFrames - 1)}
                   max={Math.max(0, source.totalVideoFrames - 1)}
                   value={frameOffset}
                   onChange={(e) => setFrameOffset(parseInt(e.target.value) || 0)}

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -81,11 +81,17 @@ export const ImageTraceControls: React.FC = () => {
       return;
     }
 
-    // Clear existing source first to ensure a clean state transition
-    // (fixes stale overlay when replacing source)
-    clearSource();
-    setLoading(true);
-    setLoadError(null);
+    // Clear existing source and enter loading state atomically
+    // (single set() call prevents a flash of non-loading UI)
+    useImageTraceStore.setState({
+      source: null,
+      enabled: false,
+      isLoading: true,
+      loadError: null,
+      frameOffset: 0,
+      position: { x: 0, y: 0 },
+      scale: 1.0,
+    });
 
     try {
       const result = fileType === 'image'
@@ -103,7 +109,7 @@ export const ImageTraceControls: React.FC = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  }, [setSource, clearSource, setLoading, setLoadError, fitToCanvas, getCanvasPixelDimensions]);
+  }, [setSource, setLoadError, fitToCanvas, getCanvasPixelDimensions]);
 
   const handleFitToCanvas = useCallback(() => {
     const dims = getCanvasPixelDimensions();

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -1,0 +1,321 @@
+/**
+ * ImageTraceControls
+ * 
+ * Popover dropdown UI for the Image Trace overlay feature.
+ * Rendered as a portal (like the typography dropdown) with all controls inline.
+ * 
+ * Controls:
+ * - File upload (image/video)
+ * - Enable/disable toggle
+ * - Opacity slider
+ * - Render order toggle (behind/in front)
+ * - Position X/Y inputs
+ * - Scale slider + fit-to-canvas button
+ * - Video frame offset (slider + input, video-only)
+ * - Clear/remove button
+ */
+
+import React, { useCallback, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Upload, Trash2, Maximize2, Film, Image as ImageIcon } from 'lucide-react';
+import { useImageTraceStore } from '@/stores/imageTraceStore';
+import { useCanvasStore } from '@/stores/canvasStore';
+import { useCanvasContext } from '@/contexts/CanvasContext';
+import {
+  classifyTraceFile,
+  getTraceFileAcceptString,
+  processTraceImage,
+  processTraceVideo,
+} from '@/utils/imageTraceProcessor';
+
+export const ImageTraceControls: React.FC = () => {
+  const {
+    enabled,
+    source,
+    opacity,
+    renderOrder,
+    frameOffset,
+    position,
+    scale,
+    isLoading,
+    loadError,
+    setSource,
+    clearSource,
+    setOpacity,
+    setRenderOrder,
+    setFrameOffset,
+    setPosition,
+    setScale,
+    fitToCanvas,
+    toggle,
+    setLoading,
+    setLoadError,
+  } = useImageTraceStore();
+
+  const canvasWidth = useCanvasStore((s) => s.width);
+  const canvasHeight = useCanvasStore((s) => s.height);
+  const { fontSize, characterSpacing, lineSpacing } = useCanvasContext();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Calculate pixel dimensions for fit-to-canvas
+  const getCanvasPixelDimensions = useCallback(() => {
+    const cellWidth = fontSize * 0.6 * characterSpacing;
+    const cellHeight = fontSize * lineSpacing;
+    return {
+      width: canvasWidth * cellWidth,
+      height: canvasHeight * cellHeight,
+    };
+  }, [canvasWidth, canvasHeight, fontSize, characterSpacing, lineSpacing]);
+
+  const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const fileType = classifyTraceFile(file);
+    if (!fileType) {
+      setLoadError('Unsupported file format');
+      return;
+    }
+
+    setLoading(true);
+    setLoadError(null);
+
+    try {
+      const result = fileType === 'image'
+        ? await processTraceImage(file)
+        : await processTraceVideo(file);
+      setSource(result);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to load file');
+    }
+
+    // Reset input so the same file can be re-selected
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, [setSource, setLoading, setLoadError]);
+
+  const handleFitToCanvas = useCallback(() => {
+    const dims = getCanvasPixelDimensions();
+    fitToCanvas(dims.width, dims.height);
+  }, [fitToCanvas, getCanvasPixelDimensions]);
+
+  return (
+    <div className="space-y-3" onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
+      {/* File Upload */}
+      {!source ? (
+        <div className="flex flex-col items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isLoading}
+            className="w-full h-8 text-xs gap-1.5"
+          >
+            <Upload className="w-3 h-3" />
+            {isLoading ? 'Loading...' : 'Upload Image or Video'}
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={getTraceFileAcceptString()}
+            onChange={handleFileSelect}
+            className="hidden"
+          />
+          {loadError && (
+            <p className="text-xs text-destructive">{loadError}</p>
+          )}
+        </div>
+      ) : (
+        <>
+          {/* Source info + Enable toggle */}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 min-w-0">
+              {source.type === 'image' ? (
+                <ImageIcon className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+              ) : (
+                <Film className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+              )}
+              <span className="text-xs text-muted-foreground truncate">{source.name}</span>
+            </div>
+            <Switch
+              checked={enabled}
+              onCheckedChange={() => toggle()}
+              aria-label="Toggle image trace"
+            />
+          </div>
+
+          {/* Opacity */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+              Opacity: {Math.round(opacity * 100)}%
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value={Math.round(opacity * 100)}
+              onChange={(e) => setOpacity(parseInt(e.target.value) / 100)}
+              className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer"
+            />
+          </div>
+
+          {/* Render Order */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+              Render Order
+            </label>
+            <div className="flex gap-1">
+              <Button
+                variant={renderOrder === 'behind' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setRenderOrder('behind')}
+                className="flex-1 h-7 text-xs"
+              >
+                Behind
+              </Button>
+              <Button
+                variant={renderOrder === 'inFront' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setRenderOrder('inFront')}
+                className="flex-1 h-7 text-xs"
+              >
+                In Front
+              </Button>
+            </div>
+          </div>
+
+          {/* Position */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+              Position
+            </label>
+            <div className="flex gap-2 items-center">
+              <div className="flex items-center gap-1">
+                <span className="text-xs text-muted-foreground w-3">X</span>
+                <input
+                  type="number"
+                  value={position.x}
+                  onChange={(e) => setPosition(parseInt(e.target.value) || 0, position.y)}
+                  className="w-16 h-6 text-xs text-center border border-border rounded bg-background text-foreground [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                />
+              </div>
+              <div className="flex items-center gap-1">
+                <span className="text-xs text-muted-foreground w-3">Y</span>
+                <input
+                  type="number"
+                  value={position.y}
+                  onChange={(e) => setPosition(position.x, parseInt(e.target.value) || 0)}
+                  className="w-16 h-6 text-xs text-center border border-border rounded bg-background text-foreground [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Scale + Fit to Canvas */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                Scale: {Math.round(scale * 100)}%
+              </label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleFitToCanvas}
+                    className="h-5 px-1.5 text-[10px] gap-1"
+                  >
+                    <Maximize2 className="w-2.5 h-2.5" />
+                    Fit
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="text-xs">Fit to canvas</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <input
+              type="range"
+              min="10"
+              max="500"
+              step="1"
+              value={Math.round(scale * 100)}
+              onChange={(e) => setScale(parseInt(e.target.value) / 100)}
+              className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground mt-0.5">
+              <span>10%</span>
+              <span>100%</span>
+              <span>500%</span>
+            </div>
+          </div>
+
+          {/* Video Frame Offset (video-only) */}
+          {source.type === 'video' && (
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+                Frame Offset: {frameOffset}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min="0"
+                  max={Math.max(0, source.totalVideoFrames - 1)}
+                  step="1"
+                  value={frameOffset}
+                  onChange={(e) => setFrameOffset(parseInt(e.target.value))}
+                  className="flex-1 h-2 bg-muted rounded-lg appearance-none cursor-pointer"
+                />
+                <input
+                  type="number"
+                  min="0"
+                  max={Math.max(0, source.totalVideoFrames - 1)}
+                  value={frameOffset}
+                  onChange={(e) => setFrameOffset(parseInt(e.target.value) || 0)}
+                  className="w-14 h-6 text-xs text-center border border-border rounded bg-background text-foreground [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                />
+              </div>
+              <div className="text-[10px] text-muted-foreground mt-1">
+                {source.totalVideoFrames} frames @ {Math.round(source.videoFps * 100) / 100} fps
+              </div>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="pt-2 border-t border-border flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex-1 h-7 text-xs gap-1"
+            >
+              <Upload className="w-3 h-3" />
+              Replace
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={clearSource}
+              className="h-7 px-2 text-xs text-destructive hover:text-destructive gap-1"
+            >
+              <Trash2 className="w-3 h-3" />
+              Remove
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={getTraceFileAcceptString()}
+              onChange={handleFileSelect}
+              className="hidden"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -51,7 +51,6 @@ export const ImageTraceControls: React.FC = () => {
     setScale,
     fitToCanvas,
     toggle,
-    setLoading,
     setLoadError,
   } = useImageTraceStore();
 
@@ -334,7 +333,7 @@ export const ImageTraceControls: React.FC = () => {
               variant="outline"
               size="sm"
               onClick={clearSource}
-              className="h-7 px-2 text-xs text-destructive hover:text-destructive gap-1"
+              className="flex-1 h-7 text-xs text-destructive hover:text-destructive gap-1"
             >
               <Trash2 className="w-3 h-3" />
               Remove

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -19,7 +19,7 @@ import React, { useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { Upload, Trash2, Maximize2, Film, Image as ImageIcon } from 'lucide-react';
+import { Upload, Trash2, Maximize2, Film, Image as ImageIcon, Loader2 } from 'lucide-react';
 import { useImageTraceStore } from '@/stores/imageTraceStore';
 import { useCanvasStore } from '@/stores/canvasStore';
 import { useCanvasContext } from '@/contexts/CanvasContext';
@@ -140,7 +140,7 @@ export const ImageTraceControls: React.FC = () => {
             disabled={isLoading}
             className="w-full h-8 text-xs gap-1.5"
           >
-            <Upload className="w-3 h-3" />
+            {isLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Upload className="w-3 h-3" />}
             {isLoading ? 'Loading...' : 'Upload Image or Video'}
           </Button>
           {loadError && (

--- a/src/components/features/ImageTraceControls.tsx
+++ b/src/components/features/ImageTraceControls.tsx
@@ -23,6 +23,7 @@ import { Upload, Trash2, Maximize2, Film, Image as ImageIcon } from 'lucide-reac
 import { useImageTraceStore } from '@/stores/imageTraceStore';
 import { useCanvasStore } from '@/stores/canvasStore';
 import { useCanvasContext } from '@/contexts/CanvasContext';
+import { useScrubInput } from '@/hooks/useScrubInput';
 import {
   classifyTraceFile,
   getTraceFileAcceptString,
@@ -80,6 +81,9 @@ export const ImageTraceControls: React.FC = () => {
       return;
     }
 
+    // Clear existing source first to ensure a clean state transition
+    // (fixes stale overlay when replacing source)
+    clearSource();
     setLoading(true);
     setLoadError(null);
 
@@ -96,15 +100,36 @@ export const ImageTraceControls: React.FC = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  }, [setSource, setLoading, setLoadError]);
+  }, [setSource, clearSource, setLoading, setLoadError]);
 
   const handleFitToCanvas = useCallback(() => {
     const dims = getCanvasPixelDimensions();
     fitToCanvas(dims.width, dims.height);
   }, [fitToCanvas, getCanvasPixelDimensions]);
 
+  // Drag-to-scrub for position X/Y (matches LayerPropertiesPanel pattern)
+  const scrubX = useScrubInput({
+    value: position.x,
+    onChange: (v) => setPosition(v, position.y),
+    step: 1,
+  });
+  const scrubY = useScrubInput({
+    value: position.y,
+    onChange: (v) => setPosition(position.x, v),
+    step: 1,
+  });
+
   return (
     <div className="space-y-3" onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
+      {/* Single persistent file input (always in DOM so ref stays valid during replace) */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={getTraceFileAcceptString()}
+        onChange={handleFileSelect}
+        className="hidden"
+      />
+
       {/* File Upload */}
       {!source ? (
         <div className="flex flex-col items-center gap-2">
@@ -118,13 +143,6 @@ export const ImageTraceControls: React.FC = () => {
             <Upload className="w-3 h-3" />
             {isLoading ? 'Loading...' : 'Upload Image or Video'}
           </Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={getTraceFileAcceptString()}
-            onChange={handleFileSelect}
-            className="hidden"
-          />
           {loadError && (
             <p className="text-xs text-destructive">{loadError}</p>
           )}
@@ -196,7 +214,10 @@ export const ImageTraceControls: React.FC = () => {
             </label>
             <div className="flex gap-2 items-center">
               <div className="flex items-center gap-1">
-                <span className="text-xs text-muted-foreground w-3">X</span>
+                <span
+                  className="text-xs text-muted-foreground w-3 cursor-ew-resize select-none"
+                  onMouseDown={scrubX.onMouseDown}
+                >X</span>
                 <input
                   type="number"
                   value={position.x}
@@ -205,7 +226,10 @@ export const ImageTraceControls: React.FC = () => {
                 />
               </div>
               <div className="flex items-center gap-1">
-                <span className="text-xs text-muted-foreground w-3">Y</span>
+                <span
+                  className="text-xs text-muted-foreground w-3 cursor-ew-resize select-none"
+                  onMouseDown={scrubY.onMouseDown}
+                >Y</span>
                 <input
                   type="number"
                   value={position.y}
@@ -306,13 +330,6 @@ export const ImageTraceControls: React.FC = () => {
               <Trash2 className="w-3 h-3" />
               Remove
             </Button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={getTraceFileAcceptString()}
-              onChange={handleFileSelect}
-              className="hidden"
-            />
           </div>
         </>
       )}

--- a/src/components/features/KeyboardShortcutsDialog.tsx
+++ b/src/components/features/KeyboardShortcutsDialog.tsx
@@ -108,6 +108,7 @@ const KEYBOARD_SHORTCUTS: ShortcutSection[] = [
       { keys: ['U'], description: 'Show/hide all keyframes' },
       { keys: ['Cmd', 'G'], description: 'Group selected layers' },
       { keys: ['Shift', 'O'], description: 'Toggle onion skinning' },
+      { keys: ['Shift', 'I'], description: 'Toggle image trace overlay' },
     ]
   },
   {

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -10,6 +10,7 @@ import { useMemoizedGrid } from './useMemoizedGrid';
 import { useDrawingTool } from './useDrawingTool';
 import { useCompositedCanvas } from './useCompositedCanvas';
 import { useOnionSkinRenderer } from './useOnionSkinRenderer';
+import { useImageTraceRenderer } from './useImageTraceRenderer';
 import { measureCanvasRender, finishCanvasRender } from '../utils/performance';
 import { 
   setupTextRendering
@@ -106,6 +107,9 @@ export const useCanvasRenderer = () => {
 
   // Use onion skin renderer for frame overlays
   const { renderOnionSkins } = useOnionSkinRenderer();
+
+  // Use image trace renderer for overlay tracing
+  const { renderImageTraceBehind, renderImageTraceInFront } = useImageTraceRenderer();
 
   // Use memoized grid for optimized rendering  
   const { selectionData, shapePreviewData } = useMemoizedGrid(
@@ -250,6 +254,9 @@ export const useCanvasRenderer = () => {
     // Render onion skin layers (previous and next frames)
     renderOnionSkins();
 
+    // Render image trace overlay behind content (if configured)
+    renderImageTraceBehind();
+
     // Set font context once for the entire render batch
     ctx.font = drawingStyles.font;
     ctx.textAlign = drawingStyles.textAlign;
@@ -304,6 +311,10 @@ export const useCanvasRenderer = () => {
         }
       }
     } // end skipBaseRenderForEffectPreview
+
+    // Render image trace overlay in front of content (if configured)
+    renderImageTraceInFront();
+
     // Draw moved cells at their new positions
     if (overlayState.moveState && overlayState.moveState.originalData.size > 0) {
       const totalOffset = getTotalOffset(overlayState.moveState);
@@ -524,6 +535,8 @@ export const useCanvasRenderer = () => {
     drawingStyles,
     getEllipsePoints,
     renderOnionSkins,
+    renderImageTraceBehind,
+    renderImageTraceInFront,
     // Preview store values
     previewData,
     isPreviewActive,

--- a/src/hooks/useImageTraceRenderer.ts
+++ b/src/hooks/useImageTraceRenderer.ts
@@ -18,6 +18,7 @@ import { useImageTraceStore } from '../stores/imageTraceStore';
 import { useTimelineStore } from '../stores/timelineStore';
 import { useAnimationStore } from '../stores/animationStore';
 import { useCanvasContext } from '../contexts/CanvasContext';
+import { useCanvasState } from './useCanvasState';
 import { getFrameForTimelinePosition } from '../utils/imageTraceProcessor';
 
 export const useImageTraceRenderer = () => {
@@ -29,13 +30,15 @@ export const useImageTraceRenderer = () => {
   const position = useImageTraceStore((s) => s.position);
   const scale = useImageTraceStore((s) => s.scale);
 
-  const { canvasRef } = useCanvasContext();
+  const { canvasRef, panOffset } = useCanvasContext();
+  const { zoom } = useCanvasState();
 
   const isLayerMode = useTimelineStore.getState().layers.length > 0;
 
   /**
    * Core render function — draws the image/video frame onto the canvas
    * at the configured position, scale, and opacity.
+   * Respects the canvas zoom level and pan offset.
    */
   const renderOverlay = useCallback(() => {
     const canvas = canvasRef.current;
@@ -59,14 +62,19 @@ export const useImageTraceRenderer = () => {
     // Apply opacity
     ctx.globalAlpha = opacity;
 
-    // Draw the source at the configured position and scale
-    const drawWidth = sourceCanvas.width * scale;
-    const drawHeight = sourceCanvas.height * scale;
-    ctx.drawImage(sourceCanvas, position.x, position.y, drawWidth, drawHeight);
+    // Apply zoom and pan offset to match the canvas coordinate system.
+    // The user's position/scale values are in unzoomed pixels; we need to
+    // transform them into the zoomed canvas space.
+    const drawWidth = sourceCanvas.width * scale * zoom;
+    const drawHeight = sourceCanvas.height * scale * zoom;
+    const drawX = position.x * zoom + panOffset.x;
+    const drawY = position.y * zoom + panOffset.y;
+
+    ctx.drawImage(sourceCanvas, drawX, drawY, drawWidth, drawHeight);
 
     // Restore context state
     ctx.restore();
-  }, [canvasRef, enabled, source, opacity, frameOffset, position, scale, isLayerMode]);
+  }, [canvasRef, enabled, source, opacity, frameOffset, position, scale, isLayerMode, zoom, panOffset]);
 
   /**
    * Render the overlay behind ASCII content.

--- a/src/hooks/useImageTraceRenderer.ts
+++ b/src/hooks/useImageTraceRenderer.ts
@@ -1,0 +1,94 @@
+/**
+ * useImageTraceRenderer
+ *
+ * Hook for rendering the image trace overlay on the canvas.
+ * Follows the same pattern as useOnionSkinRenderer — renders directly
+ * onto the display canvas and is therefore excluded from exports.
+ *
+ * Provides two render functions:
+ * - renderImageTraceBehind(): renders behind ASCII content
+ * - renderImageTraceInFront(): renders in front of ASCII content
+ *
+ * The caller (useCanvasRenderer) invokes whichever one matches the
+ * user's renderOrder setting at the appropriate point in the pipeline.
+ */
+
+import { useCallback } from 'react';
+import { useImageTraceStore } from '../stores/imageTraceStore';
+import { useTimelineStore } from '../stores/timelineStore';
+import { useAnimationStore } from '../stores/animationStore';
+import { useCanvasContext } from '../contexts/CanvasContext';
+import { getFrameForTimelinePosition } from '../utils/imageTraceProcessor';
+
+export const useImageTraceRenderer = () => {
+  const enabled = useImageTraceStore((s) => s.enabled);
+  const source = useImageTraceStore((s) => s.source);
+  const opacity = useImageTraceStore((s) => s.opacity);
+  const renderOrder = useImageTraceStore((s) => s.renderOrder);
+  const frameOffset = useImageTraceStore((s) => s.frameOffset);
+  const position = useImageTraceStore((s) => s.position);
+  const scale = useImageTraceStore((s) => s.scale);
+
+  const { canvasRef } = useCanvasContext();
+
+  const isLayerMode = useTimelineStore.getState().layers.length > 0;
+
+  /**
+   * Core render function — draws the image/video frame onto the canvas
+   * at the configured position, scale, and opacity.
+   */
+  const renderOverlay = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !enabled || !source) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Determine the current timeline frame
+    const currentFrame = isLayerMode
+      ? useTimelineStore.getState().view.currentFrame
+      : useAnimationStore.getState().currentFrameIndex;
+
+    // Get the source frame for this timeline position
+    const sourceCanvas = getFrameForTimelinePosition(source, currentFrame, frameOffset);
+    if (!sourceCanvas) return;
+
+    // Save context state
+    ctx.save();
+
+    // Apply opacity
+    ctx.globalAlpha = opacity;
+
+    // Draw the source at the configured position and scale
+    const drawWidth = sourceCanvas.width * scale;
+    const drawHeight = sourceCanvas.height * scale;
+    ctx.drawImage(sourceCanvas, position.x, position.y, drawWidth, drawHeight);
+
+    // Restore context state
+    ctx.restore();
+  }, [canvasRef, enabled, source, opacity, frameOffset, position, scale, isLayerMode]);
+
+  /**
+   * Render the overlay behind ASCII content.
+   * Called after grid background, before cell rendering.
+   */
+  const renderImageTraceBehind = useCallback(() => {
+    if (renderOrder !== 'behind') return;
+    renderOverlay();
+  }, [renderOrder, renderOverlay]);
+
+  /**
+   * Render the overlay in front of ASCII content.
+   * Called after cell rendering, before tool overlays.
+   */
+  const renderImageTraceInFront = useCallback(() => {
+    if (renderOrder !== 'inFront') return;
+    renderOverlay();
+  }, [renderOrder, renderOverlay]);
+
+  return {
+    renderImageTraceBehind,
+    renderImageTraceInFront,
+    isImageTraceEnabled: enabled && source !== null,
+  };
+};

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -24,6 +24,7 @@ import { useSelectionStore } from '../stores/selectionStore';
 import { ANSI_COLORS } from '../constants/colors';
 import type { AnyHistoryAction, CanvasHistoryAction, CanvasResizeHistoryAction, FrameId, Cell } from '../types';
 import { useTimelineStore } from '../stores/timelineStore';
+import { useImageTraceStore } from '../stores/imageTraceStore';
 import type { LayerId, LayerGroupId, ContentFrameId, PropertyTrackId, KeyframeId, PropertyPath } from '../types/timeline';
 import { PROPERTY_DEFINITIONS } from '../types/timeline';
 
@@ -1760,6 +1761,7 @@ export const useKeyboardShortcuts = () => {
   const frames = useAnimationStore((s) => s.frames);
   const selectedFrameIndices = useAnimationStore((s) => s.selectedFrameIndices);
   const toggleOnionSkin = useAnimationStore((s) => s.toggleOnionSkin);
+  const toggleImageTrace = useImageTraceStore((s) => s.toggle);
   const { zoomIn, zoomOut } = useZoomControls();
   const { showSaveProjectDialog, showSaveAsDialog, showOpenProjectDialog } = useProjectFileActions();
   
@@ -2355,6 +2357,11 @@ export const useKeyboardShortcuts = () => {
       if (event.key === 'O' || event.key === 'o') {
         event.preventDefault();
         toggleOnionSkin();
+        return;
+      }
+      if (event.key === 'I' || event.key === 'i') {
+        event.preventDefault();
+        toggleImageTrace();
         return;
       }
     }
@@ -3011,6 +3018,7 @@ export const useKeyboardShortcuts = () => {
     swapForegroundBackground,
     adjustBrushSize,
     toggleOnionSkin,
+    toggleImageTrace,
     currentFrameIndex,
     frames,
     selectedFrameIndices,

--- a/src/stores/imageTraceStore.ts
+++ b/src/stores/imageTraceStore.ts
@@ -98,7 +98,7 @@ export const useImageTraceStore = create<ImageTraceState & ImageTraceActions>((s
 
   setRenderOrder: (renderOrder) => set({ renderOrder }),
 
-  setFrameOffset: (frameOffset) => set({ frameOffset: Math.max(0, frameOffset) }),
+  setFrameOffset: (frameOffset) => set({ frameOffset }),
 
   setPosition: (x, y) => set({ position: { x, y } }),
 

--- a/src/stores/imageTraceStore.ts
+++ b/src/stores/imageTraceStore.ts
@@ -1,0 +1,144 @@
+/**
+ * Image Trace Store
+ * 
+ * Manages state for the image trace overlay feature.
+ * Allows users to upload an image or video as a translucent overlay
+ * on the canvas for tracing. This is render-only (excluded from exports)
+ * and transient (not persisted in sessions).
+ */
+
+import { create } from 'zustand';
+
+export interface ImageTraceSource {
+  type: 'image' | 'video';
+  file: File;
+  name: string;
+  /** For images: the loaded image as a canvas element */
+  imageCanvas: HTMLCanvasElement | null;
+  /** For videos: array of frame canvases (raw pixel frames, not ASCII) */
+  videoFrames: HTMLCanvasElement[];
+  /** Detected video FPS (only for video sources) */
+  videoFps: number;
+  /** Total number of video frames */
+  totalVideoFrames: number;
+  /** Original pixel dimensions of the source */
+  originalWidth: number;
+  originalHeight: number;
+}
+
+export interface ImageTraceState {
+  enabled: boolean;
+  source: ImageTraceSource | null;
+  /** Opacity of the overlay (0.0–1.0) */
+  opacity: number;
+  /** Whether the overlay renders behind or in front of ASCII content */
+  renderOrder: 'behind' | 'inFront';
+  /** Video frame offset relative to timeline (in frames) */
+  frameOffset: number;
+  /** Pixel offset for positioning the overlay */
+  position: { x: number; y: number };
+  /** Scale factor (1.0 = original size) */
+  scale: number;
+  /** Whether the source is currently being loaded/processed */
+  isLoading: boolean;
+  /** Error message if loading failed */
+  loadError: string | null;
+}
+
+export interface ImageTraceActions {
+  setSource: (source: ImageTraceSource) => void;
+  clearSource: () => void;
+  setOpacity: (opacity: number) => void;
+  setRenderOrder: (order: 'behind' | 'inFront') => void;
+  setFrameOffset: (offset: number) => void;
+  setPosition: (x: number, y: number) => void;
+  setScale: (scale: number) => void;
+  fitToCanvas: (canvasPixelWidth: number, canvasPixelHeight: number) => void;
+  toggle: () => void;
+  setEnabled: (enabled: boolean) => void;
+  setLoading: (loading: boolean) => void;
+  setLoadError: (error: string | null) => void;
+}
+
+export const useImageTraceStore = create<ImageTraceState & ImageTraceActions>((set, get) => ({
+  // State
+  enabled: false,
+  source: null,
+  opacity: 0.5,
+  renderOrder: 'behind',
+  frameOffset: 0,
+  position: { x: 0, y: 0 },
+  scale: 1.0,
+  isLoading: false,
+  loadError: null,
+
+  // Actions
+  setSource: (source) => set({ 
+    source, 
+    enabled: true, 
+    isLoading: false, 
+    loadError: null,
+    // Reset transform when loading new source
+    position: { x: 0, y: 0 },
+    scale: 1.0,
+    frameOffset: 0,
+  }),
+
+  clearSource: () => set({ 
+    source: null, 
+    enabled: false,
+    frameOffset: 0,
+    position: { x: 0, y: 0 },
+    scale: 1.0,
+    isLoading: false,
+    loadError: null,
+  }),
+
+  setOpacity: (opacity) => set({ opacity: Math.max(0, Math.min(1, opacity)) }),
+
+  setRenderOrder: (renderOrder) => set({ renderOrder }),
+
+  setFrameOffset: (frameOffset) => set({ frameOffset: Math.max(0, frameOffset) }),
+
+  setPosition: (x, y) => set({ position: { x, y } }),
+
+  setScale: (scale) => set({ scale: Math.max(0.1, Math.min(5.0, scale)) }),
+
+  fitToCanvas: (canvasPixelWidth, canvasPixelHeight) => {
+    const { source } = get();
+    if (!source) return;
+
+    const sourceWidth = source.originalWidth;
+    const sourceHeight = source.originalHeight;
+    if (sourceWidth === 0 || sourceHeight === 0) return;
+
+    // Scale to fit the canvas while maintaining aspect ratio
+    const scaleX = canvasPixelWidth / sourceWidth;
+    const scaleY = canvasPixelHeight / sourceHeight;
+    const fitScale = Math.min(scaleX, scaleY);
+
+    // Center the image
+    const scaledWidth = sourceWidth * fitScale;
+    const scaledHeight = sourceHeight * fitScale;
+    const offsetX = Math.round((canvasPixelWidth - scaledWidth) / 2);
+    const offsetY = Math.round((canvasPixelHeight - scaledHeight) / 2);
+
+    set({ 
+      scale: fitScale, 
+      position: { x: offsetX, y: offsetY } 
+    });
+  },
+
+  toggle: () => {
+    const { source, enabled } = get();
+    if (source) {
+      set({ enabled: !enabled });
+    }
+  },
+
+  setEnabled: (enabled) => set({ enabled }),
+
+  setLoading: (isLoading) => set({ isLoading }),
+
+  setLoadError: (loadError) => set({ loadError, isLoading: false }),
+}));

--- a/src/utils/imageTraceProcessor.ts
+++ b/src/utils/imageTraceProcessor.ts
@@ -1,0 +1,248 @@
+/**
+ * Image Trace Processor
+ * 
+ * Utility for loading images and extracting raw video frames for the
+ * image trace overlay feature. Unlike mediaProcessor.ts, this does NOT
+ * convert to ASCII — it preserves the original pixel data for overlay rendering.
+ * 
+ * Video frame extraction follows the same 1:1 frame mapping pattern used
+ * by the media import system: each video frame maps to one timeline frame,
+ * with no FPS resampling.
+ */
+
+import * as MP4Box from 'mp4box';
+import type { MP4File, MP4Info } from 'mp4box';
+import type { ImageTraceSource } from '../stores/imageTraceStore';
+
+type Mp4ArrayBuffer = ArrayBuffer & { fileStart?: number };
+
+const SUPPORTED_IMAGE_TYPES = [
+  'image/jpeg', 'image/jpg', 'image/png', 'image/gif',
+  'image/bmp', 'image/webp', 'image/svg+xml'
+];
+
+const SUPPORTED_VIDEO_TYPES = [
+  'video/mp4', 'video/webm', 'video/ogg', 'video/avi',
+  'video/mov', 'video/quicktime', 'video/wmv'
+];
+
+/**
+ * Determine if a file is a supported image or video type
+ */
+export function classifyTraceFile(file: File): 'image' | 'video' | null {
+  if (SUPPORTED_IMAGE_TYPES.includes(file.type)) return 'image';
+  if (SUPPORTED_VIDEO_TYPES.includes(file.type)) return 'video';
+  return null;
+}
+
+/**
+ * Get the accept string for the file input
+ */
+export function getTraceFileAcceptString(): string {
+  return [...SUPPORTED_IMAGE_TYPES, ...SUPPORTED_VIDEO_TYPES].join(',');
+}
+
+/**
+ * Load an image file as an HTMLCanvasElement (raw pixels, no processing)
+ */
+export async function processTraceImage(file: File): Promise<ImageTraceSource> {
+  const img = await loadImage(file);
+  
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(img, 0, 0);
+
+  // Clean up the object URL
+  URL.revokeObjectURL(img.src);
+
+  return {
+    type: 'image',
+    file,
+    name: file.name,
+    imageCanvas: canvas,
+    videoFrames: [],
+    videoFps: 0,
+    totalVideoFrames: 0,
+    originalWidth: img.width,
+    originalHeight: img.height,
+  };
+}
+
+/**
+ * Extract all frames from a video file as raw pixel canvases.
+ * Uses the same center-sampling pattern as mediaProcessor.ts.
+ * 1:1 frame mapping — no FPS resampling.
+ */
+export async function processTraceVideo(file: File): Promise<ImageTraceSource> {
+  const video = await loadVideo(file);
+  const fps = await detectVideoFps(video, file);
+  const totalFrames = Math.floor(video.duration * fps);
+  const frames: HTMLCanvasElement[] = [];
+
+  for (let i = 0; i < totalFrames; i++) {
+    // Sample at the CENTER of each frame's time window
+    const targetTimestamp = (i + 0.5) / fps;
+    if (targetTimestamp >= video.duration) break;
+
+    video.currentTime = targetTimestamp;
+
+    // Wait for seeked event
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => resolve(), 500);
+      const handleSeeked = () => {
+        clearTimeout(timeout);
+        video.removeEventListener('seeked', handleSeeked);
+        resolve();
+      };
+      video.addEventListener('seeked', handleSeeked);
+    });
+
+    // Wait for browser to render the frame (double RAF)
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+
+    // Extra delay for first frame decoding
+    if (i === 0) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    // Draw frame to a new canvas
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d')!;
+    ctx.drawImage(video, 0, 0);
+    frames.push(canvas);
+  }
+
+  // Clean up
+  URL.revokeObjectURL(video.src);
+
+  return {
+    type: 'video',
+    file,
+    name: file.name,
+    imageCanvas: null,
+    videoFrames: frames,
+    videoFps: fps,
+    totalVideoFrames: frames.length,
+    originalWidth: video.videoWidth,
+    originalHeight: video.videoHeight,
+  };
+}
+
+/**
+ * Get the correct video frame canvas for a given timeline frame position.
+ * Applies the user's frame offset. Returns null if out of range.
+ */
+export function getFrameForTimelinePosition(
+  source: ImageTraceSource,
+  timelineFrame: number,
+  frameOffset: number
+): HTMLCanvasElement | null {
+  if (source.type === 'image') {
+    return source.imageCanvas;
+  }
+
+  // Video: 1:1 frame mapping with offset
+  const videoFrameIndex = timelineFrame - frameOffset;
+  if (videoFrameIndex < 0 || videoFrameIndex >= source.videoFrames.length) {
+    return null;
+  }
+  return source.videoFrames[videoFrameIndex];
+}
+
+// ── Internal helpers ──
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image: ${file.name}`));
+    img.src = URL.createObjectURL(file);
+  });
+}
+
+function loadVideo(file: File): Promise<HTMLVideoElement> {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.onloadedmetadata = () => resolve(video);
+    video.onerror = () => reject(new Error(`Failed to load video: ${file.name}`));
+    video.src = URL.createObjectURL(file);
+  });
+}
+
+/**
+ * Detect video FPS using MP4Box metadata, falling back to 30fps.
+ * Same logic as mediaProcessor.ts estimateVideoFrameRate.
+ */
+async function detectVideoFps(video: HTMLVideoElement, file: File): Promise<number> {
+  try {
+    const arrayBuffer = await file.arrayBuffer();
+    const fps = await parseMP4FrameRate(arrayBuffer);
+    if (fps > 0) return fps;
+  } catch {
+    // Fall through to default
+  }
+  return 30;
+}
+
+function parseMP4FrameRate(arrayBuffer: ArrayBuffer): Promise<number> {
+  return new Promise((resolve) => {
+    const mp4boxFile: MP4File = MP4Box.createFile();
+
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      const allArgs = args.map(arg => String(arg)).join(' ');
+      if (allArgs.includes('BoxParser') || allArgs.includes('Invalid box type') || allArgs.includes('©')) {
+        return;
+      }
+      originalError.apply(console, args);
+    };
+
+    mp4boxFile.onReady = (info: MP4Info) => {
+      console.error = originalError;
+      const videoTrack = info.videoTracks?.[0];
+      if (videoTrack) {
+        let frameRate = 0;
+        if (videoTrack.movie_timescale && videoTrack.movie_duration) {
+          const durationInSeconds = videoTrack.movie_duration / videoTrack.movie_timescale;
+          if (videoTrack.nb_samples && durationInSeconds > 0) {
+            frameRate = videoTrack.nb_samples / durationInSeconds;
+          }
+        }
+        if (!frameRate && videoTrack.timescale) {
+          const commonRates = [23.976, 24, 25, 29.97, 30, 50, 59.94, 60];
+          for (const rate of commonRates) {
+            if (Math.abs(videoTrack.timescale / 1000 - rate) < 1) {
+              frameRate = rate;
+              break;
+            }
+          }
+          if (!frameRate && videoTrack.timescale > 1000) {
+            frameRate = videoTrack.timescale / 1000;
+          }
+        }
+        resolve(frameRate > 0 && frameRate <= 120 ? frameRate : 0);
+      } else {
+        resolve(0);
+      }
+    };
+
+    mp4boxFile.onError = () => {
+      console.error = originalError;
+      resolve(0);
+    };
+
+    const buffer = arrayBuffer as Mp4ArrayBuffer;
+    buffer.fileStart = 0;
+    mp4boxFile.appendBuffer(buffer);
+    mp4boxFile.flush();
+  });
+}


### PR DESCRIPTION
## Summary

Adds an **Image Trace** feature that lets users upload an image or video as a translucent overlay on the canvas for tracing. The overlay is render-only (excluded from exports) and transient (not persisted in sessions).

## Features

- **Image & video support** — Upload PNG/JPG/GIF/WebP images or MP4/WebM/MOV videos
- **Opacity control** — Adjustable overlay transparency (0–100%)
- **Render order toggle** — Place overlay behind or in front of ASCII content
- **Position & scale** — X/Y position with drag-to-scrub, scale slider (10–500%), fit-to-canvas button
- **Video frame offset** — Slider + numeric input to align video frames to the timeline (supports negative offsets)
- **1:1 frame mapping** — Video frames map directly to timeline frames (no FPS resampling)
- **Auto fit-to-canvas** — Assets automatically scale to fit on load
- **Zoom integration** — Overlay respects canvas zoom level and pan offset
- **Keyboard shortcut** — `Shift+I` to toggle
- **Loading indicator** — Spinner on upload button during processing

## Files Changed

### New files
- `src/stores/imageTraceStore.ts` — Zustand store
- `src/utils/imageTraceProcessor.ts` — Image/video loading & frame extraction
- `src/hooks/useImageTraceRenderer.ts` — Canvas overlay rendering hook
- `src/components/features/ImageTraceControls.tsx` — Popover dropdown UI

### Modified files
- `src/hooks/useCanvasRenderer.ts` — Integrated render calls
- `src/components/features/CanvasSettings.tsx` — Header button
- `src/hooks/useKeyboardShortcuts.ts` — Shift+I shortcut
- `src/components/features/KeyboardShortcutsDialog.tsx` — Shortcut docs

## Testing

- 379/379 tests passing
- 0 new lint warnings (2 pre-existing errors unchanged)