### PR TITLE
feat: wire up unlimited layers for pro/admin accounts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { ExportImportButtons } from './components/features/ExportImportButtons'
 import { useCloudDialogState } from './hooks/useCloudDialogState'
 import { useCloudProjectActions } from './hooks/useCloudProjectActions'
 import { useAuth, usePasswordRecoveryCallback, useEmailVerificationCallback, UpdatePasswordDialog, SignInDialog } from '@ascii-motion/premium'
+import { registerSubscriptionLayerLimit, FREE_TIER_MAX_LAYERS, UNLIMITED_LAYERS } from './utils/layerLimits'
 import { AsciiMotionLogo } from './components/common/AsciiMotionLogo'
 import { InlineProjectNameEditor } from './components/features/InlineProjectNameEditor'
 import { SaveToCloudDialog } from './components/features/SaveToCloudDialog'
@@ -70,8 +71,18 @@ function AppContent() {
   const { setFontSize, setCharacterSpacing, setLineSpacing, setSelectedFontId } = useCanvasContext()
   
   // Cloud storage state and actions
-  const { user } = useAuth()
+  const { user, profile } = useAuth()
   const { loadFromCloud } = useCloudProject()
+
+  // Register subscription-aware layer limit
+  // Pro/admin users get unlimited layers, free users get FREE_TIER_MAX_LAYERS (5)
+  useEffect(() => {
+    registerSubscriptionLayerLimit(() => {
+      if (profile?.is_admin) return UNLIMITED_LAYERS;
+      if (profile?.subscription_tier?.name === 'pro') return UNLIMITED_LAYERS;
+      return FREE_TIER_MAX_LAYERS;
+    });
+  }, [profile]);
   const { 
     showSaveToCloudDialog, 
     showProjectsDialog,


### PR DESCRIPTION
## Summary

Wires up the existing `registerSubscriptionLayerLimit()` infrastructure so that pro and admin users bypass the 5-layer free tier limit.

### What changed
- **`src/App.tsx`** — In `AppContent`, destructure `profile` from `useAuth()` and call `registerSubscriptionLayerLimit()` in a `useEffect` that re-runs when the profile changes.
- Pro users (`subscription_tier.name === 'pro'`) and admins (`is_admin`) get `UNLIMITED_LAYERS` (-1 sentinel)
- Free/unauthenticated users continue to get `FREE_TIER_MAX_LAYERS` (5)

### What was already built
The layer limit infrastructure was fully implemented but never connected to auth:
- `src/utils/layerLimits.ts` — `registerSubscriptionLayerLimit()`, `canAddLayer()`, `getImportableLayerCount()`
- `src/hooks/useLayerLimit.ts` — React hook for UI components
- `src/stores/timelineStore.ts` — `addLayer()` and `duplicateLayer()` already call `canAddLayer()`
- All 23 existing layer limit tests pass

### Security
- No premium code exposed — the registration bridges the premium auth context to the open-source layer utility via the existing getter pattern
- Graceful fallback: if premium package is absent (open-source contributors), `useAuth()` returns `profile: null`, so the getter returns `FREE_TIER_MAX_LAYERS`