### PR TITLE
feat: add image sequence export and improve SVG compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "figlet": "^1.9.3",
         "file-saver": "^2.0.5",
         "isomorphic-dompurify": "^2.16.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.542.0",
         "mp4box": "^2.1.1",
         "opentype.js": "^1.3.4",
@@ -5265,6 +5266,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -6813,6 +6820,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6854,7 +6867,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -7047,6 +7059,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7299,6 +7317,18 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7331,6 +7361,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -8055,6 +8094,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8501,6 +8546,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8787,6 +8838,21 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -9012,6 +9078,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9098,6 +9170,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -9348,6 +9426,15 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "figlet": "^1.9.3",
     "file-saver": "^2.0.5",
     "isomorphic-dompurify": "^2.16.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.542.0",
     "mp4box": "^2.1.1",
     "opentype.js": "^1.3.4",

--- a/src/components/features/ImageExportDialog.tsx
+++ b/src/components/features/ImageExportDialog.tsx
@@ -8,7 +8,7 @@ import { Badge } from '../ui/badge';
 import { Switch } from '../ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Slider } from '../ui/slider';
-import { FileImage, Download, Settings, Loader2, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { FileImage, Download, Settings, Loader2, CheckCircle2, AlertTriangle, Film } from 'lucide-react';
 import { useExportStore } from '../../stores/exportStore';
 import { useExportDataCollector } from '../../utils/exportDataCollector';
 import { useProjectMetadataStore } from '../../stores/projectMetadataStore';
@@ -62,8 +62,13 @@ export const ImageExportDialog: React.FC = () => {
 	const projectName = useProjectMetadataStore((state) => state.projectName);
 	const { selectedFontId, actualFont: canvasActualFont, isFontDetecting: canvasIsFontDetecting } = useCanvasContext();
 	const postEffectTracks = useTimelineStore((s) => s.postEffectTracks);
+	const timelineConfig = useTimelineStore((s) => s.config);
 
 	const [filename, setFilename] = useState(projectName || 'ascii-motion-frame');
+	const [sequenceMode, setSequenceMode] = useState(false);
+	const [entireTimeline, setEntireTimeline] = useState(true);
+	const [rangeStart, setRangeStart] = useState(1);
+	const [rangeEnd, setRangeEnd] = useState(1);
 	const [svgFontStatus, setSvgFontStatus] = useState<{
 		isDetecting: boolean;
 		actualFont: string | null;
@@ -80,6 +85,17 @@ export const ImageExportDialog: React.FC = () => {
 			setFilename(projectName);
 		}
 	}, [isOpen, projectName]);
+
+	// Initialize range end to total frame count when dialog opens or timeline changes
+	useEffect(() => {
+		if (isOpen && exportData) {
+			const totalFrames = exportData.frames.length;
+			setRangeEnd(totalFrames);
+			if (rangeStart > totalFrames) {
+				setRangeStart(1);
+			}
+		}
+	}, [isOpen, exportData?.frames.length]);
 
 	// Detect font for SVG export (use canvas context font detection if available, otherwise detect)
 	useEffect(() => {
@@ -186,7 +202,17 @@ export const ImageExportDialog: React.FC = () => {
 				setProgress(progress);
 			});
 
-			if (imageSettings.format === 'svg') {
+			if (sequenceMode) {
+				const totalFrames = exportData.frames.length;
+				const sequenceSettings = {
+					...imageSettings,
+					sequenceMode: true as const,
+					sequenceRange: entireTimeline
+						? 'all' as const
+						: { start: rangeStart - 1, end: Math.min(rangeEnd - 1, totalFrames - 1) },
+				};
+				await renderer.exportImageSequence(exportData, sequenceSettings, filename);
+			} else if (imageSettings.format === 'svg') {
 				await renderer.exportSvg(exportData, imageSettings, filename);
 			} else {
 				await renderer.exportImage(exportData, imageSettings, filename);
@@ -258,13 +284,96 @@ export const ImageExportDialog: React.FC = () => {
 								disabled={isExporting}
 							/>
 							<Badge variant="outline" className="ml-2 self-center">
-								.{fileExtension}
+								{sequenceMode ? '.zip' : `.${fileExtension}`}
 							</Badge>
+						</div>
+
+						{/* Export Mode Toggle */}
+						<div className="flex items-center gap-3 pt-2">
+							<Button
+								variant={!sequenceMode ? 'default' : 'outline'}
+								size="sm"
+								onClick={() => setSequenceMode(false)}
+								disabled={isExporting}
+								className="flex-1"
+							>
+								<FileImage className="w-3.5 h-3.5 mr-1.5" />
+								Current Frame
+							</Button>
+							<Button
+								variant={sequenceMode ? 'default' : 'outline'}
+								size="sm"
+								onClick={() => setSequenceMode(true)}
+								disabled={isExporting}
+								className="flex-1"
+							>
+								<Film className="w-3.5 h-3.5 mr-1.5" />
+								Image Sequence
+							</Button>
 						</div>
 					</div>
 
 					{/* Scrollable Settings */}
 					<div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+						{/* Frame Range Settings (sequence mode only) */}
+						{sequenceMode && (
+							<Card className="border-border/50">
+								<CardContent className="pt-4 space-y-4">
+									<div className="flex items-center gap-2 mb-1">
+										<Film className="w-4 h-4" />
+										<span className="text-sm font-medium">Frame Range</span>
+									</div>
+
+									<div className="flex items-center justify-between">
+										<div className="space-y-0.5">
+											<Label htmlFor="entire-timeline">Entire Timeline</Label>
+											<p className="text-xs text-muted-foreground">
+												Export all {exportData?.frames.length || 0} frames
+											</p>
+										</div>
+										<Switch
+											id="entire-timeline"
+											checked={entireTimeline}
+											onCheckedChange={setEntireTimeline}
+											disabled={isExporting}
+										/>
+									</div>
+
+									{!entireTimeline && (
+										<div className="grid grid-cols-2 gap-3">
+											<div className="space-y-1">
+												<Label htmlFor="range-start">Start Frame</Label>
+												<Input
+													id="range-start"
+													type="number"
+													min={1}
+													max={rangeEnd}
+													value={rangeStart}
+													onChange={(e) => setRangeStart(Math.max(1, Math.min(parseInt(e.target.value) || 1, rangeEnd)))}
+													disabled={isExporting}
+												/>
+											</div>
+											<div className="space-y-1">
+												<Label htmlFor="range-end">End Frame</Label>
+												<Input
+													id="range-end"
+													type="number"
+													min={rangeStart}
+													max={exportData?.frames.length || 1}
+													value={rangeEnd}
+													onChange={(e) => setRangeEnd(Math.max(rangeStart, Math.min(parseInt(e.target.value) || 1, exportData?.frames.length || 1)))}
+													disabled={isExporting}
+												/>
+											</div>
+											<p className="col-span-2 text-xs text-muted-foreground">
+												{rangeEnd - rangeStart + 1} frame{rangeEnd - rangeStart + 1 !== 1 ? 's' : ''} will be exported
+											</p>
+										</div>
+									)}
+								</CardContent>
+							</Card>
+						)}
+
 						<Card className="border-border/50">
 							<CardContent className="pt-4 space-y-4">
 								<div className="flex items-center gap-2 mb-1">
@@ -493,14 +602,34 @@ export const ImageExportDialog: React.FC = () => {
 						</Card>
 
 						<div className="text-center p-3 bg-muted/50 rounded-lg space-y-1">
-							<p className="text-sm text-muted-foreground">Current frame will be exported as</p>
-							<p className="text-sm font-medium">
-								{filename}.{fileExtension}
-								{imageSettings.format !== 'svg' && ` (${imageSettings.sizeMultiplier}x scale)`}
-								{imageSettings.format === 'svg' && ' (vector)'}
-							</p>
-							{estimatedSize && (
-								<p className="text-xs text-muted-foreground">Estimated size: {estimatedSize}</p>
+							{sequenceMode ? (
+								<>
+									<p className="text-sm text-muted-foreground">Image sequence will be exported as</p>
+									<p className="text-sm font-medium">
+										{filename}_sequence.zip
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{(() => {
+											const totalFrames = exportData?.frames.length || 0;
+											const frameCount = entireTimeline ? totalFrames : (rangeEnd - rangeStart + 1);
+											const padLen = Math.max(String(frameCount).length, 1);
+											const example = `${filename}_${'1'.padStart(padLen, '0')}.${fileExtension}`;
+											return `${frameCount} file${frameCount !== 1 ? 's' : ''}: ${example} → ${filename}_${String(frameCount).padStart(padLen, '0')}.${fileExtension}`;
+										})()}
+									</p>
+								</>
+							) : (
+								<>
+									<p className="text-sm text-muted-foreground">Current frame will be exported as</p>
+									<p className="text-sm font-medium">
+										{filename}.{fileExtension}
+										{imageSettings.format !== 'svg' && ` (${imageSettings.sizeMultiplier}x scale)`}
+										{imageSettings.format === 'svg' && ' (vector)'}
+									</p>
+									{estimatedSize && (
+										<p className="text-xs text-muted-foreground">Estimated size: {estimatedSize}</p>
+									)}
+								</>
 							)}
 						</div>
 					</div>
@@ -519,7 +648,7 @@ export const ImageExportDialog: React.FC = () => {
 							) : (
 								<>
 									<Download className="w-4 h-4 mr-2" />
-									Export Image
+									{sequenceMode ? 'Export Sequence (.zip)' : 'Export Image'}
 								</>
 							)}
 						</Button>

--- a/src/stores/exportStore.ts
+++ b/src/stores/exportStore.ts
@@ -65,6 +65,8 @@ const DEFAULT_IMAGE_SETTINGS: ImageExportSettings = {
   format: 'png',
   quality: 90,
   svgSettings: DEFAULT_SVG_SETTINGS,
+  sequenceMode: false,
+  sequenceRange: 'all',
 };
 
 const DEFAULT_VIDEO_SETTINGS: VideoExportSettings = {

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -33,6 +33,9 @@ export interface ImageExportSettings {
   includePostEffects?: boolean; // Apply WebGL post effects (default: true)
   // SVG-specific settings (only used when format === 'svg')
   svgSettings?: SvgExportSettings;
+  // Image sequence export settings
+  sequenceMode?: boolean; // true = export all frames as a sequence, false/undefined = current frame only
+  sequenceRange?: { start: number; end: number } | 'all'; // Frame range (0-indexed) or 'all' for entire timeline
 }
 
 export interface ReactExportSettings {

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -170,6 +170,7 @@ export interface ExportDataBundle {
     characterSpacing: number;
     lineSpacing: number;
     selectedFontId: string;
+    actualFont?: string | null; // The font actually detected/rendered (for SVG export compatibility)
   };
   
   // Tool state (for session saves)

--- a/src/utils/exportDataCollector.ts
+++ b/src/utils/exportDataCollector.ts
@@ -303,7 +303,8 @@ export const useExportDataCollector = (enabled: boolean = true): ExportDataBundl
     fontSize,
     characterSpacing,
     lineSpacing,
-    selectedFontId
+    selectedFontId,
+    actualFont
   } = useCanvasContext();
 
   // Get theme context (must be called before early return — React hooks rules)
@@ -373,7 +374,8 @@ export const useExportDataCollector = (enabled: boolean = true): ExportDataBundl
       fontSize,
       characterSpacing,
       lineSpacing,
-      selectedFontId
+      selectedFontId,
+      actualFont
     },
     
     // Tool state

--- a/src/utils/exportRenderer.ts
+++ b/src/utils/exportRenderer.ts
@@ -1,4 +1,5 @@
 import { saveAs } from 'file-saver';
+import JSZip from 'jszip';
 import type { Font } from 'opentype.js';
 import type { 
   ExportDataBundle, 
@@ -304,6 +305,222 @@ export class ExportRenderer {
       console.error('SVG export failed:', error);
       throw new Error(`SVG export failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
+  }
+
+  /**
+   * Export frames as an image sequence packaged in a .zip file.
+   * Supports PNG, JPEG, and SVG formats.
+   */
+  async exportImageSequence(
+    data: ExportDataBundle,
+    settings: ImageExportSettings,
+    filename: string
+  ): Promise<void> {
+    this.updateProgress('Preparing image sequence export...', 0);
+
+    try {
+      const totalFrames = data.frames.length;
+      if (totalFrames === 0) {
+        throw new Error('No frames available for export');
+      }
+
+      // Determine frame range
+      let startFrame = 0;
+      let endFrame = totalFrames - 1;
+
+      if (settings.sequenceRange && settings.sequenceRange !== 'all') {
+        startFrame = Math.max(0, settings.sequenceRange.start);
+        endFrame = Math.min(totalFrames - 1, settings.sequenceRange.end);
+      }
+
+      const frameCount = endFrame - startFrame + 1;
+      // Dynamic zero-padding based on total frame count
+      const padLength = Math.max(String(frameCount).length, 1);
+      const extension = settings.format === 'jpg' ? 'jpg' : settings.format === 'svg' ? 'svg' : 'png';
+
+      const zip = new JSZip();
+
+      // Pre-load font for SVG text-as-outlines if needed
+      let svgFont: Font | undefined;
+      if (settings.format === 'svg' && settings.svgSettings?.textAsOutlines) {
+        this.updateProgress('Loading font for outlines...', 2);
+        const { fontLoader } = await import('./font/fontLoader');
+        const fontId = settings.svgSettings.outlineFont || 'jetbrains-mono';
+        try {
+          const loadedFont = await fontLoader.loadFont(fontId, { cache: true, timeout: 10000 });
+          svgFont = loadedFont.font;
+        } catch {
+          svgFont = undefined;
+        }
+      }
+
+      // Reusable canvas for raster exports
+      let exportCanvas: { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D; scale: number } | null = null;
+      if (settings.format !== 'svg') {
+        exportCanvas = this.createExportCanvas(
+          data.canvasDimensions.width,
+          data.canvasDimensions.height,
+          settings.sizeMultiplier,
+          data.fontMetrics,
+          data.typography
+        );
+      }
+
+      for (let i = startFrame; i <= endFrame; i++) {
+        const frameIndex = i - startFrame;
+        const frameNumber = frameIndex + 1; // 1-indexed
+        const paddedNumber = String(frameNumber).padStart(padLength, '0');
+        const frameFilename = `${filename}_${paddedNumber}.${extension}`;
+
+        const progressPercent = Math.round((frameIndex / frameCount) * 90) + 5;
+        this.updateProgress(`Rendering frame ${frameNumber}/${frameCount}...`, progressPercent);
+
+        const frameData = data.frames[i]?.data || data.canvasData;
+
+        if (settings.format === 'svg') {
+          // Generate SVG for this frame
+          const svgContent = this.renderFrameAsSvg(
+            frameData,
+            data,
+            settings,
+            svgFont
+          );
+          zip.file(frameFilename, svgContent);
+        } else {
+          // Render raster frame
+          await this.renderFrame(
+            exportCanvas!.canvas,
+            frameData,
+            data.canvasDimensions.width,
+            data.canvasDimensions.height,
+            {
+              backgroundColor: data.canvasBackgroundColor,
+              showGrid: settings.includeGrid && data.showGrid,
+              fontMetrics: data.fontMetrics,
+              typography: data.typography,
+              sizeMultiplier: settings.sizeMultiplier,
+              theme: data.uiState.theme,
+              scale: exportCanvas!.scale
+            }
+          );
+
+          // Apply post effects if enabled
+          if (settings.includePostEffects !== false && data.postEffectTracks) {
+            applyPostEffectsToCanvas(
+              exportCanvas!.canvas,
+              data.postEffectTracks,
+              i,
+              data.frameRate,
+              data.canvasBackgroundColor,
+            );
+          }
+
+          const mimeType = settings.format === 'jpg' ? 'image/jpeg' : 'image/png';
+          const quality = settings.format === 'jpg' ? Math.min(Math.max(settings.quality, 10), 100) / 100 : undefined;
+          const blob = await this.canvasToBlob(exportCanvas!.canvas, mimeType, quality);
+          zip.file(frameFilename, blob);
+        }
+      }
+
+      this.updateProgress('Creating zip file...', 95);
+
+      const zipBlob = await zip.generateAsync({ type: 'blob' });
+      saveAs(zipBlob, `${filename}_sequence.zip`);
+
+      this.updateProgress('Export complete!', 100);
+    } catch (error) {
+      console.error('Image sequence export failed:', error);
+      throw new Error(`Image sequence export failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Render a single frame as SVG string (used by image sequence export)
+   */
+  private renderFrameAsSvg(
+    frameData: Map<string, Cell>,
+    data: ExportDataBundle,
+    settings: ImageExportSettings,
+    font?: Font
+  ): string {
+    const svgSettings = settings.svgSettings!;
+
+    const actualFontSize = data.typography?.fontSize || data.fontMetrics?.fontSize || 16;
+    const characterSpacing = data.typography?.characterSpacing || 1.0;
+    const lineSpacing = data.typography?.lineSpacing || 1.0;
+
+    const baseCharWidth = actualFontSize * 0.6;
+    const baseCharHeight = actualFontSize;
+
+    const cellWidth = baseCharWidth * characterSpacing;
+    const cellHeight = baseCharHeight * lineSpacing;
+
+    const canvasWidth = data.canvasDimensions.width * cellWidth;
+    const canvasHeight = data.canvasDimensions.height * cellHeight;
+
+    let svg = generateSvgHeader(
+      canvasWidth,
+      canvasHeight,
+      svgSettings.includeBackground ? data.canvasBackgroundColor : undefined
+    );
+
+    if (svgSettings.includeGrid) {
+      const gridColor = calculateAdaptiveGridColor(
+        data.canvasBackgroundColor,
+        data.uiState.theme as 'light' | 'dark'
+      );
+      svg += generateSvgGrid(
+        data.canvasDimensions.width,
+        data.canvasDimensions.height,
+        cellWidth,
+        cellHeight,
+        gridColor
+      );
+    }
+
+    svg += '  <g id="content">\n';
+
+    const fontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
+
+    frameData.forEach((cell, key) => {
+      const [x, y] = key.split(',').map(Number);
+
+      if (cell.char) {
+        if (svgSettings.textAsOutlines) {
+          svg += convertTextToPath(
+            cell.char,
+            x, y,
+            cell.color || '#ffffff',
+            cell.bgColor,
+            cellWidth,
+            cellHeight,
+            actualFontSize,
+            fontStack,
+            font
+          );
+        } else {
+          svg += generateSvgTextElement(
+            cell.char,
+            x, y,
+            cell.color || '#ffffff',
+            cell.bgColor,
+            cellWidth,
+            cellHeight,
+            actualFontSize,
+            fontStack
+          );
+        }
+      }
+    });
+
+    svg += '  </g>\n';
+    svg += '</svg>';
+
+    if (!svgSettings.prettify) {
+      svg = minifySvg(svg);
+    }
+
+    return svg;
   }
 
   /**

--- a/src/utils/exportRenderer.ts
+++ b/src/utils/exportRenderer.ts
@@ -199,9 +199,10 @@ export class ExportRenderer {
       const canvasWidth = data.canvasDimensions.width * cellWidth;
       const canvasHeight = data.canvasDimensions.height * cellHeight;
 
-      // Sanitize the font stack for desktop app compatibility
+      // Sanitize the font stack for desktop app compatibility — use the actually
+      // detected font when available to avoid Adobe apps choking on uninstalled fonts
       const rawFontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
-      const fontStack = sanitizeFontStackForSvg(rawFontStack);
+      const fontStack = sanitizeFontStackForSvg(rawFontStack, data.typography?.actualFont);
 
       this.updateProgress('Generating SVG structure...', 20);
 
@@ -462,7 +463,7 @@ export class ExportRenderer {
     const canvasHeight = data.canvasDimensions.height * cellHeight;
 
     const rawFontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
-    const fontStack = sanitizeFontStackForSvg(rawFontStack);
+    const fontStack = sanitizeFontStackForSvg(rawFontStack, data.typography?.actualFont);
 
     let svg = generateSvgHeader(
       canvasWidth,

--- a/src/utils/exportRenderer.ts
+++ b/src/utils/exportRenderer.ts
@@ -25,6 +25,7 @@ import {
   generateSvgHeader, 
   generateSvgGrid, 
   generateSvgTextElement, 
+  generateSvgContentGrouped,
   convertTextToPath,
   minifySvg,
   sanitizeFontStackForSvg
@@ -247,15 +248,15 @@ export class ExportRenderer {
       // Content group
       svg += '  <g id="content">\n';
 
-      // Render each cell
-      let cellCount = 0;
-      const totalCells = currentFrame.size;
-      
-      currentFrame.forEach((cell, key) => {
-        const [x, y] = key.split(',').map(Number);
+      if (svgSettings.textAsOutlines) {
+        // Text-as-outlines: render each cell individually with path conversion
+        let cellCount = 0;
+        const totalCells = currentFrame.size;
         
-        if (cell.char) {
-          if (svgSettings.textAsOutlines) {
+        currentFrame.forEach((cell, key) => {
+          const [x, y] = key.split(',').map(Number);
+          
+          if (cell.char) {
             svg += convertTextToPath(
               cell.char,
               x, y,
@@ -265,28 +266,27 @@ export class ExportRenderer {
               cellHeight,
               actualFontSize,
               fontStack,
-              font // Pass the loaded font for opentype.js conversion
-            );
-          } else {
-            svg += generateSvgTextElement(
-              cell.char,
-              x, y,
-              cell.color || '#ffffff',
-              cell.bgColor,
-              cellWidth,
-              cellHeight,
-              actualFontSize,
-              fontStack
+              font
             );
           }
-        }
-        
-        cellCount++;
-        if (cellCount % 100 === 0) {
-          const progress = 50 + Math.floor((cellCount / totalCells) * 30);
-          this.updateProgress(`Rendering characters... (${cellCount}/${totalCells})`, progress);
-        }
-      });
+          
+          cellCount++;
+          if (cellCount % 100 === 0) {
+            const progress = 50 + Math.floor((cellCount / totalCells) * 30);
+            this.updateProgress(`Rendering characters... (${cellCount}/${totalCells})`, progress);
+          }
+        });
+      } else {
+        // Row-based grouped rendering — dramatically fewer SVG elements
+        // for compatibility with After Effects and other desktop apps
+        svg += generateSvgContentGrouped(
+          currentFrame,
+          data.canvasDimensions.width,
+          data.canvasDimensions.height,
+          cellWidth,
+          cellHeight
+        );
+      }
 
       svg += '  </g>\n';
       svg += '</svg>';
@@ -488,11 +488,11 @@ export class ExportRenderer {
 
     svg += '  <g id="content">\n';
 
-    frameData.forEach((cell, key) => {
-      const [x, y] = key.split(',').map(Number);
+    if (svgSettings.textAsOutlines) {
+      frameData.forEach((cell, key) => {
+        const [x, y] = key.split(',').map(Number);
 
-      if (cell.char) {
-        if (svgSettings.textAsOutlines) {
+        if (cell.char) {
           svg += convertTextToPath(
             cell.char,
             x, y,
@@ -504,20 +504,17 @@ export class ExportRenderer {
             fontStack,
             font
           );
-        } else {
-          svg += generateSvgTextElement(
-            cell.char,
-            x, y,
-            cell.color || '#ffffff',
-            cell.bgColor,
-            cellWidth,
-            cellHeight,
-            actualFontSize,
-            fontStack
-          );
         }
-      }
-    });
+      });
+    } else {
+      svg += generateSvgContentGrouped(
+        frameData,
+        data.canvasDimensions.width,
+        data.canvasDimensions.height,
+        cellWidth,
+        cellHeight
+      );
+    }
 
     svg += '  </g>\n';
     svg += '</svg>';

--- a/src/utils/exportRenderer.ts
+++ b/src/utils/exportRenderer.ts
@@ -24,7 +24,6 @@ import { applyPostEffectsToCanvas } from '../hooks/usePostEffectsRenderer';
 import { 
   generateSvgHeader, 
   generateSvgGrid, 
-  generateSvgTextElement, 
   generateSvgContentGrouped,
   convertTextToPath,
   minifySvg,

--- a/src/utils/exportRenderer.ts
+++ b/src/utils/exportRenderer.ts
@@ -26,7 +26,8 @@ import {
   generateSvgGrid, 
   generateSvgTextElement, 
   convertTextToPath,
-  minifySvg
+  minifySvg,
+  sanitizeFontStackForSvg
 } from './svgExportUtils';
 import { getPostEffect } from '../registry/postEffectRegistry';
 import { evaluatePostEffectBlock, getActivePostEffects } from './postEffectsPipeline';
@@ -198,13 +199,18 @@ export class ExportRenderer {
       const canvasWidth = data.canvasDimensions.width * cellWidth;
       const canvasHeight = data.canvasDimensions.height * cellHeight;
 
+      // Sanitize the font stack for desktop app compatibility
+      const rawFontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
+      const fontStack = sanitizeFontStackForSvg(rawFontStack);
+
       this.updateProgress('Generating SVG structure...', 20);
 
-      // Start SVG with header
+      // Start SVG with header and embedded text style
       let svg = generateSvgHeader(
         canvasWidth, 
         canvasHeight, 
-        svgSettings.includeBackground ? data.canvasBackgroundColor : undefined
+        svgSettings.includeBackground ? data.canvasBackgroundColor : undefined,
+        { fontFamily: fontStack, fontSize: actualFontSize }
       );
 
       // Add metadata as SVG comments
@@ -239,9 +245,6 @@ export class ExportRenderer {
 
       // Content group
       svg += '  <g id="content">\n';
-
-      // Font stack is already properly formatted (no quotes) from fontMetrics
-      const fontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
 
       // Render each cell
       let cellCount = 0;
@@ -458,10 +461,14 @@ export class ExportRenderer {
     const canvasWidth = data.canvasDimensions.width * cellWidth;
     const canvasHeight = data.canvasDimensions.height * cellHeight;
 
+    const rawFontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
+    const fontStack = sanitizeFontStackForSvg(rawFontStack);
+
     let svg = generateSvgHeader(
       canvasWidth,
       canvasHeight,
-      svgSettings.includeBackground ? data.canvasBackgroundColor : undefined
+      svgSettings.includeBackground ? data.canvasBackgroundColor : undefined,
+      { fontFamily: fontStack, fontSize: actualFontSize }
     );
 
     if (svgSettings.includeGrid) {
@@ -479,8 +486,6 @@ export class ExportRenderer {
     }
 
     svg += '  <g id="content">\n';
-
-    const fontStack = data.fontMetrics?.fontFamily || 'SF Mono, Monaco, Cascadia Code, Consolas, JetBrains Mono, Fira Code, Monaspace Neon, Geist Mono, Courier New, monospace';
 
     frameData.forEach((cell, key) => {
       const [x, y] = key.split(',').map(Number);

--- a/src/utils/svgExportUtils.ts
+++ b/src/utils/svgExportUtils.ts
@@ -23,13 +23,26 @@ const CSS_ONLY_FONT_KEYWORDS = new Set([
 
 /**
  * Sanitize a CSS font stack for SVG export.
- * Removes CSS-only keywords that desktop apps can't resolve,
- * and ensures we always end with a generic 'monospace' fallback.
+ * For desktop app compatibility (Illustrator, After Effects), we should only
+ * include fonts that are actually available — not the entire CSS fallback chain.
+ * If an actualFont is provided (from font detection), use only that + monospace.
+ * Otherwise, filter out CSS-only keywords and keep the stack.
  */
-export function sanitizeFontStackForSvg(fontStack: string): string {
+export function sanitizeFontStackForSvg(fontStack: string, actualFont?: string | null): string {
+  // If we know the actual detected font, use only that + generic fallback.
+  // This prevents Adobe apps from trying (and failing) to load every font
+  // in the CSS fallback chain.
+  if (actualFont) {
+    const bare = actualFont.replace(/['"]/g, '');
+    if (CSS_ONLY_FONT_KEYWORDS.has(bare) || bare === 'monospace') {
+      return 'monospace';
+    }
+    return `${actualFont}, monospace`;
+  }
+
+  // Fallback: filter out CSS-only keywords from the stack
   const fonts = fontStack.split(',').map(f => f.trim()).filter(f => f.length > 0);
   const sanitized = fonts.filter(f => {
-    // Remove quotes for comparison
     const bare = f.replace(/['"]/g, '');
     return !CSS_ONLY_FONT_KEYWORDS.has(bare);
   });

--- a/src/utils/svgExportUtils.ts
+++ b/src/utils/svgExportUtils.ts
@@ -28,25 +28,28 @@ const CSS_ONLY_FONT_KEYWORDS = new Set([
  * include fonts that are actually available — not the entire CSS fallback chain.
  * If an actualFont is provided (from font detection), use only that + monospace.
  * Otherwise, filter out CSS-only keywords and keep the stack.
+ *
+ * Multi-word font names are single-quoted per SVG/CSS spec (e.g. 'SF Mono').
+ * After Effects' SVG parser is strict about this — unquoted multi-word names crash it.
  */
 export function sanitizeFontStackForSvg(fontStack: string, actualFont?: string | null): string {
   // If we know the actual detected font, use only that + generic fallback.
-  // This prevents Adobe apps from trying (and failing) to load every font
-  // in the CSS fallback chain.
   if (actualFont) {
     const bare = actualFont.replace(/['"]/g, '');
     if (CSS_ONLY_FONT_KEYWORDS.has(bare) || bare === 'monospace') {
       return 'monospace';
     }
-    return `${actualFont}, monospace`;
+    return `${quoteFontName(bare)}, monospace`;
   }
 
   // Fallback: filter out CSS-only keywords from the stack
   const fonts = fontStack.split(',').map(f => f.trim()).filter(f => f.length > 0);
-  const sanitized = fonts.filter(f => {
-    const bare = f.replace(/['"]/g, '');
-    return !CSS_ONLY_FONT_KEYWORDS.has(bare);
-  });
+  const sanitized = fonts
+    .filter(f => {
+      const bare = f.replace(/['"]/g, '');
+      return !CSS_ONLY_FONT_KEYWORDS.has(bare);
+    })
+    .map(f => quoteFontName(f.replace(/['"]/g, '')));
 
   // Ensure we have at least a generic fallback
   if (sanitized.length === 0 || sanitized[sanitized.length - 1] !== 'monospace') {
@@ -54,6 +57,14 @@ export function sanitizeFontStackForSvg(fontStack: string, actualFont?: string |
   }
 
   return sanitized.join(', ');
+}
+
+/** Single-quote a font name if it contains spaces; leave generic families unquoted. */
+function quoteFontName(name: string): string {
+  const generic = ['monospace', 'serif', 'sans-serif', 'cursive', 'fantasy'];
+  if (generic.includes(name)) return name;
+  if (name.includes(' ')) return `'${name}'`;
+  return name;
 }
 
 /**

--- a/src/utils/svgExportUtils.ts
+++ b/src/utils/svgExportUtils.ts
@@ -78,7 +78,11 @@ export function generateSvgHeader(
     _currentTextStyle = textStyle;
   }
   
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n${bgRect}`;
+  // Round dimensions to avoid floating-point noise (e.g. 863.9999999999999)
+  const w = Math.round(width * 100) / 100;
+  const h = Math.round(height * 100) / 100;
+  
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">\n${bgRect}`;
 }
 
 // Module-level state to pass text style from header to content generators
@@ -144,25 +148,24 @@ export function generateSvgTextElement(
     elements += `    <rect x="${rectX}" y="${rectY}" width="${cellWidth}" height="${cellHeight}" fill="${bgColor}"/>\n`;
   }
   
-  // Text element centered in cell
+  // Text element — position y at baseline offset for approximate vertical centering
   const textX = x * cellWidth + cellWidth / 2;
-  const textY = y * cellHeight + cellHeight / 2;
+  const textY = y * cellHeight + fontSize * 0.85;
   
   const escapedChar = escapeXml(char);
   const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
   
-  // Use dy="0.35em" for vertical centering — this is widely supported
-  // unlike dominant-baseline="central" which crashes After Effects
-  elements += `    <text x="${textX}" y="${textY}" dy="0.35em" fill="${color}" font-family="${escapedFontFamily}" font-size="${fontSize}px" text-anchor="middle">${escapedChar}</text>\n`;
+  elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${escapedFontFamily}" font-size="${fontSize}" text-anchor="middle">${escapedChar}</text>\n`;
   
   return elements;
 }
 
 /**
- * Generate optimized SVG content from a frame's cell data using row-based grouping.
- * Instead of one <text> per character (which crashes After Effects with large canvases),
- * this groups characters by row and merges consecutive same-color runs into single
- * <tspan> elements. Typically reduces element count by 10-50x.
+ * Generate SVG content from a frame's cell data.
+ * Uses individual <text> elements with minimal attributes — no <tspan>,
+ * no dominant-baseline, no CSS classes. After Effects cannot parse <tspan>
+ * elements and crashes on import. Simple <text> elements with only x, y,
+ * fill, font-family, and font-size are the safest cross-app format.
  */
 export function generateSvgContentGrouped(
   frameData: Map<string, Cell>,
@@ -175,9 +178,6 @@ export function generateSvgContentGrouped(
   const style = getCurrentTextStyle();
   const fontFamily = style ? style.fontFamily.replace(/"/g, '&quot;') : 'monospace';
   const fontSize = style?.fontSize ?? 16;
-
-  // Shared inline attributes for <text> elements (no CSS classes for AE compat)
-  const textAttrs = `font-family="${fontFamily}" font-size="${fontSize}px" text-anchor="middle"`;
 
   // Build a 2D grid for efficient row-based traversal
   type CellInfo = { char: string; color: string; bgColor?: string };
@@ -192,58 +192,30 @@ export function generateSvgContentGrouped(
     }
   });
 
+  // Helper to round coordinates and avoid floating-point noise
+  const r = (n: number) => Math.round(n * 100) / 100;
+
   for (let row = 0; row < gridHeight; row++) {
     const rowCells = grid[row];
-    const textY = row * cellHeight + cellHeight / 2;
+    // Position y at the baseline offset for approximate vertical centering
+    const textY = r(row * cellHeight + fontSize * 0.85);
 
     // Emit background rects for this row
     for (let col = 0; col < gridWidth; col++) {
       const cell = rowCells[col];
       if (cell?.bgColor && cell.bgColor !== 'transparent') {
-        svg += `    <rect x="${col * cellWidth}" y="${row * cellHeight}" width="${cellWidth}" height="${cellHeight}" fill="${cell.bgColor}"/>\n`;
+        svg += `    <rect x="${r(col * cellWidth)}" y="${r(row * cellHeight)}" width="${r(cellWidth)}" height="${r(cellHeight)}" fill="${cell.bgColor}"/>\n`;
       }
     }
 
-    // Build color runs for this row
-    type ColorRun = { color: string; spans: { x: number; char: string }[] };
-    const runs: ColorRun[] = [];
-    let currentRun: ColorRun | null = null;
-
+    // Emit individual <text> elements — no <tspan> for AE compatibility
     for (let col = 0; col < gridWidth; col++) {
       const cell = rowCells[col];
-      if (!cell) {
-        currentRun = null;
-        continue;
-      }
+      if (!cell) continue;
 
-      if (currentRun && currentRun.color === cell.color) {
-        currentRun.spans.push({ x: col, char: cell.char });
-      } else {
-        currentRun = { color: cell.color, spans: [{ x: col, char: cell.char }] };
-        runs.push(currentRun);
-      }
-    }
-
-    if (runs.length === 0) continue;
-
-    // Emit one <text> per row with <tspan> children, using dy for vertical centering
-    if (runs.length === 1) {
-      const run = runs[0];
-      svg += `    <text ${textAttrs} y="${textY}" dy="0.35em" fill="${run.color}">`;
-      for (const span of run.spans) {
-        const textX = span.x * cellWidth + cellWidth / 2;
-        svg += `<tspan x="${textX}">${escapeXml(span.char)}</tspan>`;
-      }
-      svg += '</text>\n';
-    } else {
-      svg += `    <text ${textAttrs} y="${textY}" dy="0.35em">`;
-      for (const run of runs) {
-        for (const span of run.spans) {
-          const textX = span.x * cellWidth + cellWidth / 2;
-          svg += `<tspan x="${textX}" fill="${run.color}">${escapeXml(span.char)}</tspan>`;
-        }
-      }
-      svg += '</text>\n';
+      const textX = r(col * cellWidth + cellWidth / 2);
+      const escapedChar = escapeXml(cell.char);
+      svg += `    <text x="${textX}" y="${textY}" fill="${cell.color}" font-family="${fontFamily}" font-size="${fontSize}" text-anchor="middle">${escapedChar}</text>\n`;
     }
   }
 
@@ -340,9 +312,9 @@ function convertTextToPathPixelTracing(
   if (!ctx) {
     // Fallback to text element if canvas context unavailable
     const textX = x * cellWidth + cellWidth / 2;
-    const textY = y * cellHeight + cellHeight / 2;
+    const textY = y * cellHeight + fontSize * 0.85;
     const escapedChar = escapeXml(char);
-    elements += `    <text x="${textX}" y="${textY}" dy="0.35em" fill="${color}" font-family="${fontFamily.replace(/"/g, '&quot;')}" font-size="${fontSize}px" text-anchor="middle">${escapedChar}</text>\n`;
+    elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${fontFamily.replace(/"/g, '&quot;')}" font-size="${fontSize}" text-anchor="middle">${escapedChar}</text>\n`;
     return elements;
   }
   
@@ -371,9 +343,9 @@ function convertTextToPathPixelTracing(
   } else {
     // Fallback to text element if path extraction fails
     const textX = x * cellWidth + cellWidth / 2;
-    const textY = y * cellHeight + cellHeight / 2;
+    const textY = y * cellHeight + fontSize * 0.85;
     const escapedChar = escapeXml(char);
-    elements += `    <text x="${textX}" y="${textY}" dy="0.35em" fill="${color}" font-family="${fontFamily.replace(/"/g, '&quot;')}" font-size="${fontSize}px" text-anchor="middle">${escapedChar}</text>\n`;
+    elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${fontFamily.replace(/"/g, '&quot;')}" font-size="${fontSize}" text-anchor="middle">${escapedChar}</text>\n`;
   }
   
   return elements;

--- a/src/utils/svgExportUtils.ts
+++ b/src/utils/svgExportUtils.ts
@@ -7,18 +7,60 @@ import type { Font } from 'opentype.js';
 import { convertGlyphToSvgPath, generateSvgPathElement } from './font/opentypePathConverter';
 
 /**
- * Generate SVG header with proper namespaces and viewBox
+ * CSS-only font keywords and system UI keywords that are not valid font names
+ * in desktop applications like Adobe Illustrator, After Effects, etc.
+ * These must be filtered out of SVG font-family attributes.
+ */
+const CSS_ONLY_FONT_KEYWORDS = new Set([
+  'ui-monospace',
+  'ui-sans-serif',
+  'ui-serif',
+  'ui-rounded',
+  'system-ui',
+  '-apple-system',
+  'BlinkMacSystemFont',
+]);
+
+/**
+ * Sanitize a CSS font stack for SVG export.
+ * Removes CSS-only keywords that desktop apps can't resolve,
+ * and ensures we always end with a generic 'monospace' fallback.
+ */
+export function sanitizeFontStackForSvg(fontStack: string): string {
+  const fonts = fontStack.split(',').map(f => f.trim()).filter(f => f.length > 0);
+  const sanitized = fonts.filter(f => {
+    // Remove quotes for comparison
+    const bare = f.replace(/['"]/g, '');
+    return !CSS_ONLY_FONT_KEYWORDS.has(bare);
+  });
+
+  // Ensure we have at least a generic fallback
+  if (sanitized.length === 0 || sanitized[sanitized.length - 1] !== 'monospace') {
+    sanitized.push('monospace');
+  }
+
+  return sanitized.join(', ');
+}
+
+/**
+ * Generate SVG header with proper namespaces and viewBox.
+ * Optionally embeds a <style> element for shared text styles to reduce SVG size.
  */
 export function generateSvgHeader(
   width: number,
   height: number,
-  backgroundColor?: string
+  backgroundColor?: string,
+  textStyle?: { fontFamily: string; fontSize: number }
 ): string {
   const bgRect = backgroundColor
     ? `  <rect width="100%" height="100%" fill="${backgroundColor}"/>\n`
     : '';
   
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n${bgRect}`;
+  const styleBlock = textStyle
+    ? `  <style>\n    .t { font-family: ${textStyle.fontFamily}; font-size: ${textStyle.fontSize}px; text-anchor: middle; dominant-baseline: central; }\n  </style>\n`
+    : '';
+  
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n${styleBlock}${bgRect}`;
 }
 
 /**
@@ -50,7 +92,9 @@ export function generateSvgGrid(
 }
 
 /**
- * Generate SVG text element for a character
+ * Generate SVG text element for a character.
+ * When useClass is true (default), uses the shared CSS class 't' instead of
+ * inlining font-family/font-size on each element, drastically reducing SVG size.
  */
 export function generateSvgTextElement(
   char: string,
@@ -61,7 +105,8 @@ export function generateSvgTextElement(
   cellWidth: number,
   cellHeight: number,
   fontSize: number,
-  fontFamily: string
+  fontFamily: string,
+  useClass: boolean = true
 ): string {
   let elements = '';
   
@@ -79,10 +124,14 @@ export function generateSvgTextElement(
   // Escape special XML characters
   const escapedChar = escapeXml(char);
   
-  // Escape quotes in font-family for XML attribute
-  const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
-  
-  elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${escapedFontFamily}, monospace" font-size="${fontSize}px" text-anchor="middle" dominant-baseline="central">${escapedChar}</text>\n`;
+  if (useClass) {
+    // Use shared CSS class — much smaller output
+    elements += `    <text class="t" x="${textX}" y="${textY}" fill="${color}">${escapedChar}</text>\n`;
+  } else {
+    // Inline everything (legacy fallback)
+    const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
+    elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${escapedFontFamily}, monospace" font-size="${fontSize}px" text-anchor="middle" dominant-baseline="central">${escapedChar}</text>\n`;
+  }
   
   return elements;
 }
@@ -179,8 +228,7 @@ function convertTextToPathPixelTracing(
     const textX = x * cellWidth + cellWidth / 2;
     const textY = y * cellHeight + cellHeight / 2;
     const escapedChar = escapeXml(char);
-    const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
-    elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${escapedFontFamily}, monospace" font-size="${fontSize}px" text-anchor="middle" dominant-baseline="central">${escapedChar}</text>\n`;
+    elements += `    <text class="t" x="${textX}" y="${textY}" fill="${color}">${escapedChar}</text>\n`;
     return elements;
   }
   
@@ -211,8 +259,7 @@ function convertTextToPathPixelTracing(
     const textX = x * cellWidth + cellWidth / 2;
     const textY = y * cellHeight + cellHeight / 2;
     const escapedChar = escapeXml(char);
-    const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
-    elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${escapedFontFamily}, monospace" font-size="${fontSize}px" text-anchor="middle" dominant-baseline="central">${escapedChar}</text>\n`;
+    elements += `    <text class="t" x="${textX}" y="${textY}" fill="${color}">${escapedChar}</text>\n`;
   }
   
   return elements;

--- a/src/utils/svgExportUtils.ts
+++ b/src/utils/svgExportUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Font } from 'opentype.js';
+import type { Cell } from '../types';
 import { convertGlyphToSvgPath, generateSvgPathElement } from './font/opentypePathConverter';
 
 /**
@@ -147,6 +148,92 @@ export function generateSvgTextElement(
   }
   
   return elements;
+}
+
+/**
+ * Generate optimized SVG content from a frame's cell data using row-based grouping.
+ * Instead of one <text> per character (which crashes After Effects with large canvases),
+ * this groups characters by row and merges consecutive same-color runs into single
+ * <tspan> elements. Typically reduces element count by 10-50x.
+ */
+export function generateSvgContentGrouped(
+  frameData: Map<string, Cell>,
+  gridWidth: number,
+  gridHeight: number,
+  cellWidth: number,
+  cellHeight: number
+): string {
+  let svg = '';
+
+  // Build a 2D grid for efficient row-based traversal
+  type CellInfo = { char: string; color: string; bgColor?: string };
+  const grid: (CellInfo | null)[][] = Array.from({ length: gridHeight }, () =>
+    Array.from({ length: gridWidth }, () => null)
+  );
+
+  frameData.forEach((cell, key) => {
+    const [x, y] = key.split(',').map(Number);
+    if (x >= 0 && x < gridWidth && y >= 0 && y < gridHeight && cell.char) {
+      grid[y][x] = { char: cell.char, color: cell.color || '#ffffff', bgColor: cell.bgColor };
+    }
+  });
+
+  for (let row = 0; row < gridHeight; row++) {
+    const rowCells = grid[row];
+    const textY = row * cellHeight + cellHeight / 2;
+
+    // Emit background rects for this row
+    for (let col = 0; col < gridWidth; col++) {
+      const cell = rowCells[col];
+      if (cell?.bgColor && cell.bgColor !== 'transparent') {
+        svg += `    <rect x="${col * cellWidth}" y="${row * cellHeight}" width="${cellWidth}" height="${cellHeight}" fill="${cell.bgColor}"/>\n`;
+      }
+    }
+
+    // Build color runs for this row
+    type ColorRun = { color: string; spans: { x: number; char: string }[] };
+    const runs: ColorRun[] = [];
+    let currentRun: ColorRun | null = null;
+
+    for (let col = 0; col < gridWidth; col++) {
+      const cell = rowCells[col];
+      if (!cell) {
+        currentRun = null;
+        continue;
+      }
+
+      if (currentRun && currentRun.color === cell.color) {
+        currentRun.spans.push({ x: col, char: cell.char });
+      } else {
+        currentRun = { color: cell.color, spans: [{ x: col, char: cell.char }] };
+        runs.push(currentRun);
+      }
+    }
+
+    if (runs.length === 0) continue;
+
+    // Emit one <text> per row with <tspan> children
+    if (runs.length === 1) {
+      const run = runs[0];
+      svg += `    <text class="t" y="${textY}" fill="${run.color}">`;
+      for (const span of run.spans) {
+        const textX = span.x * cellWidth + cellWidth / 2;
+        svg += `<tspan x="${textX}">${escapeXml(span.char)}</tspan>`;
+      }
+      svg += '</text>\n';
+    } else {
+      svg += `    <text class="t" y="${textY}">`;
+      for (const run of runs) {
+        for (const span of run.spans) {
+          const textX = span.x * cellWidth + cellWidth / 2;
+          svg += `<tspan x="${textX}" fill="${run.color}">${escapeXml(span.char)}</tspan>`;
+        }
+      }
+      svg += '</text>\n';
+    }
+  }
+
+  return svg;
 }
 
 /**

--- a/src/utils/svgExportUtils.ts
+++ b/src/utils/svgExportUtils.ts
@@ -58,7 +58,9 @@ export function sanitizeFontStackForSvg(fontStack: string, actualFont?: string |
 
 /**
  * Generate SVG header with proper namespaces and viewBox.
- * Optionally embeds a <style> element for shared text styles to reduce SVG size.
+ * Uses a <defs> block with inline presentation attributes for text styling
+ * rather than CSS <style> — After Effects does not support <style> elements
+ * or CSS properties like dominant-baseline, and crashes on import.
  */
 export function generateSvgHeader(
   width: number,
@@ -70,11 +72,22 @@ export function generateSvgHeader(
     ? `  <rect width="100%" height="100%" fill="${backgroundColor}"/>\n`
     : '';
   
-  const styleBlock = textStyle
-    ? `  <style>\n    .t { font-family: ${textStyle.fontFamily}; font-size: ${textStyle.fontSize}px; text-anchor: middle; dominant-baseline: central; }\n  </style>\n`
-    : '';
+  // Store textStyle params for use by text generation functions.
+  // We avoid <style> blocks entirely for After Effects compatibility.
+  if (textStyle) {
+    _currentTextStyle = textStyle;
+  }
   
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n${styleBlock}${bgRect}`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n${bgRect}`;
+}
+
+// Module-level state to pass text style from header to content generators
+// without threading it through every call. Reset per export.
+let _currentTextStyle: { fontFamily: string; fontSize: number } | null = null;
+
+/** Get the current text style set by generateSvgHeader */
+export function getCurrentTextStyle(): { fontFamily: string; fontSize: number } | null {
+  return _currentTextStyle;
 }
 
 /**
@@ -107,8 +120,9 @@ export function generateSvgGrid(
 
 /**
  * Generate SVG text element for a character.
- * When useClass is true (default), uses the shared CSS class 't' instead of
- * inlining font-family/font-size on each element, drastically reducing SVG size.
+ * Uses inline presentation attributes (no CSS classes or dominant-baseline)
+ * for maximum compatibility with After Effects and other desktop apps.
+ * Vertical centering uses dy="0.35em" instead of dominant-baseline="central".
  */
 export function generateSvgTextElement(
   char: string,
@@ -119,8 +133,7 @@ export function generateSvgTextElement(
   cellWidth: number,
   cellHeight: number,
   fontSize: number,
-  fontFamily: string,
-  useClass: boolean = true
+  fontFamily: string
 ): string {
   let elements = '';
   
@@ -135,17 +148,12 @@ export function generateSvgTextElement(
   const textX = x * cellWidth + cellWidth / 2;
   const textY = y * cellHeight + cellHeight / 2;
   
-  // Escape special XML characters
   const escapedChar = escapeXml(char);
+  const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
   
-  if (useClass) {
-    // Use shared CSS class — much smaller output
-    elements += `    <text class="t" x="${textX}" y="${textY}" fill="${color}">${escapedChar}</text>\n`;
-  } else {
-    // Inline everything (legacy fallback)
-    const escapedFontFamily = fontFamily.replace(/"/g, '&quot;');
-    elements += `    <text x="${textX}" y="${textY}" fill="${color}" font-family="${escapedFontFamily}, monospace" font-size="${fontSize}px" text-anchor="middle" dominant-baseline="central">${escapedChar}</text>\n`;
-  }
+  // Use dy="0.35em" for vertical centering — this is widely supported
+  // unlike dominant-baseline="central" which crashes After Effects
+  elements += `    <text x="${textX}" y="${textY}" dy="0.35em" fill="${color}" font-family="${escapedFontFamily}" font-size="${fontSize}px" text-anchor="middle">${escapedChar}</text>\n`;
   
   return elements;
 }
@@ -164,6 +172,12 @@ export function generateSvgContentGrouped(
   cellHeight: number
 ): string {
   let svg = '';
+  const style = getCurrentTextStyle();
+  const fontFamily = style ? style.fontFamily.replace(/"/g, '&quot;') : 'monospace';
+  const fontSize = style?.fontSize ?? 16;
+
+  // Shared inline attributes for <text> elements (no CSS classes for AE compat)
+  const textAttrs = `font-family="${fontFamily}" font-size="${fontSize}px" text-anchor="middle"`;
 
   // Build a 2D grid for efficient row-based traversal
   type CellInfo = { char: string; color: string; bgColor?: string };
@@ -212,17 +226,17 @@ export function generateSvgContentGrouped(
 
     if (runs.length === 0) continue;
 
-    // Emit one <text> per row with <tspan> children
+    // Emit one <text> per row with <tspan> children, using dy for vertical centering
     if (runs.length === 1) {
       const run = runs[0];
-      svg += `    <text class="t" y="${textY}" fill="${run.color}">`;
+      svg += `    <text ${textAttrs} y="${textY}" dy="0.35em" fill="${run.color}">`;
       for (const span of run.spans) {
         const textX = span.x * cellWidth + cellWidth / 2;
         svg += `<tspan x="${textX}">${escapeXml(span.char)}</tspan>`;
       }
       svg += '</text>\n';
     } else {
-      svg += `    <text class="t" y="${textY}">`;
+      svg += `    <text ${textAttrs} y="${textY}" dy="0.35em">`;
       for (const run of runs) {
         for (const span of run.spans) {
           const textX = span.x * cellWidth + cellWidth / 2;
@@ -328,7 +342,7 @@ function convertTextToPathPixelTracing(
     const textX = x * cellWidth + cellWidth / 2;
     const textY = y * cellHeight + cellHeight / 2;
     const escapedChar = escapeXml(char);
-    elements += `    <text class="t" x="${textX}" y="${textY}" fill="${color}">${escapedChar}</text>\n`;
+    elements += `    <text x="${textX}" y="${textY}" dy="0.35em" fill="${color}" font-family="${fontFamily.replace(/"/g, '&quot;')}" font-size="${fontSize}px" text-anchor="middle">${escapedChar}</text>\n`;
     return elements;
   }
   
@@ -359,7 +373,7 @@ function convertTextToPathPixelTracing(
     const textX = x * cellWidth + cellWidth / 2;
     const textY = y * cellHeight + cellHeight / 2;
     const escapedChar = escapeXml(char);
-    elements += `    <text class="t" x="${textX}" y="${textY}" fill="${color}">${escapedChar}</text>\n`;
+    elements += `    <text x="${textX}" y="${textY}" dy="0.35em" fill="${color}" font-family="${fontFamily.replace(/"/g, '&quot;')}" font-size="${fontSize}px" text-anchor="middle">${escapedChar}</text>\n`;
   }
   
   return elements;


### PR DESCRIPTION
## Summary

Adds image sequence export to the image export dialog and improves SVG export compatibility with Adobe desktop apps.

### Image Sequence Export
- New toggle in the image export dialog: "Current Frame" vs "Image Sequence"
- Supports exporting frame ranges or the entire timeline
- All existing image formats (PNG, JPEG, SVG)
- Exports as a `.zip` file with frames named `{filename}_0001.{ext}`, `{filename}_0002.{ext}`, etc.
- 1-indexed frame numbers with dynamic zero-padding based on total frame count

### SVG Export Compatibility Fixes
- **Illustrator**: Fixed font-family errors by using the actually detected font instead of the full CSS fallback chain (which included uninstalled fonts like Cascadia Code, JetBrains Mono, etc.)
- **Illustrator**: Filtered out CSS-only font keywords (`ui-monospace`, `system-ui`, etc.) that aren't valid in desktop SVG renderers
- **General**: Removed `<style>` block, `dominant-baseline`, `<tspan>`, and `dy` attributes that aren't well-supported across all SVG renderers
- **General**: Added proper single-quoting of multi-word font names in `font-family` attributes per SVG/CSS spec
- **General**: Rounded floating-point coordinate values to avoid noise (e.g. `863.9999999999999` → `864`)

### Known Issue
- SVG imports into **After Effects** still crash with a thread render stack overflow. The crash occurs even on very small canvases (2×4), so it's not related to element count. Further investigation needed — SVGs work correctly in Illustrator, Figma, and browsers.

### Files Changed
- `src/components/features/ImageExportDialog.tsx` — UI for sequence mode
- `src/utils/exportRenderer.ts` — `exportImageSequence()` method, SVG rendering updates
- `src/utils/svgExportUtils.ts` — Font sanitization, grouped rendering, AE compat fixes
- `src/utils/exportDataCollector.ts` — Pass `actualFont` from canvas context
- `src/types/export.ts` — New types for sequence settings
- `src/stores/exportStore.ts` — Default sequence settings
- `package.json` / `package-lock.json` — Added `jszip` dependency