### PR TITLE
Fix blank/uneditable frame after splitting a content frame

### DIFF
--- a/src/__tests__/layerCompositing.test.ts
+++ b/src/__tests__/layerCompositing.test.ts
@@ -432,6 +432,25 @@ describe('getContentFrameAtTime', () => {
     const layer = makeLayer({ id: 'l1', contentFrames: [] });
     expect(getContentFrameAtTime(layer, 0)).toBeNull();
   });
+
+  // Regression: splitting a frame that has a later frame used to leave the
+  // contentFrames array unsorted, which made the binary search miss the new
+  // (split) frame and render it blank/uneditable. The lookup must stay correct
+  // even if the array is not sorted by startFrame.
+  it('finds a frame even when contentFrames are not sorted by startFrame', () => {
+    const cfA = makeContentFrame('cfA', 0, 5, new Map()); // [0,5)
+    const cfLater = makeContentFrame('cfLater', 10, 10, new Map()); // [10,20)
+    const cfSplit = makeContentFrame('cfSplit', 5, 5, new Map()); // [5,10)
+    // Deliberately out of order (as .concat() would leave it after a split):
+    const layer = makeLayer({ id: 'l1', contentFrames: [cfA, cfLater, cfSplit] });
+
+    expect(getContentFrameAtTime(layer, 5)).toBe(cfSplit);
+    expect(getContentFrameAtTime(layer, 9)).toBe(cfSplit);
+    expect(getContentFrameAtTime(layer, 4)).toBe(cfA);
+    expect(getContentFrameAtTime(layer, 15)).toBe(cfLater);
+    // Genuine gap still returns null even with an unsorted array.
+    expect(getContentFrameAtTime(layer, 25)).toBeNull();
+  });
 });
 
 // ============================================

--- a/src/__tests__/timelineStore.test.ts
+++ b/src/__tests__/timelineStore.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useTimelineStore } from '../stores/timelineStore';
+import { getContentFrameAtTime } from '../utils/layerCompositing';
 import type { LayerId, PropertyTrackId } from '../types/timeline';
 
 // ============================================
@@ -319,6 +320,32 @@ describe('timelineStore', () => {
       // Frame 2 is in the gap between [0,1) and [5,8)
       const atFrame2 = useTimelineStore.getState().getContentFrameAt(layerId, 2);
       expect(atFrame2).toBeNull();
+    });
+
+    // Regression: splitting a frame that has a later frame on the same layer used
+    // to append the new (split) frame out of startFrame order. That broke the
+    // binary search in getContentFrameAtTime(), so the new frame couldn't be found
+    // and rendered blank / uneditable on the canvas.
+    it('splitContentFrame keeps frames sorted and findable when a later frame exists', () => {
+      const store = useTimelineStore.getState();
+      // Frame to split spans [5,15); a later frame [20,25) must exist to trigger the bug.
+      const splitFrameId = store.addContentFrame(layerId, 5, 10)!;
+      store.addContentFrame(layerId, 20, 5);
+
+      const newFrameId = useTimelineStore.getState().splitContentFrame(layerId, splitFrameId, 10);
+      expect(newFrameId).not.toBeNull();
+
+      const layer = useTimelineStore.getState().getLayer(layerId)!;
+
+      // contentFrames must stay sorted by startFrame (binary-search invariant).
+      const starts = layer.contentFrames.map((cf) => cf.startFrame);
+      expect(starts).toEqual([...starts].sort((a, b) => a - b));
+
+      // The new (split) frame must be locatable via the binary-search path that the
+      // canvas/frame-sync uses — not just the store's linear getContentFrameAt.
+      const found = getContentFrameAtTime(layer, 12);
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(newFrameId);
     });
   });
 

--- a/src/stores/timelineStore.ts
+++ b/src/stores/timelineStore.ts
@@ -1080,10 +1080,13 @@ export const useTimelineStore = create<TimelineState>()(
         get().ensureTimelineContains(frameEnd - 1);
       }
 
+      // Keep contentFrames sorted by startFrame so getContentFrameAtTime()'s
+      // binary search stays valid (a frame may be inserted into a gap before
+      // existing frames, e.g. via paste/undo).
       set((state) => ({
         layers: updateLayer(state.layers, layerId, (l) => ({
           ...l,
-          contentFrames: [...l.contentFrames, newFrame],
+          contentFrames: [...l.contentFrames, newFrame].sort((a, b) => a.startFrame - b.startFrame),
         })),
       }));
 
@@ -1191,15 +1194,23 @@ export const useTimelineStore = create<TimelineState>()(
         data: new Map(cf.data), // Clone data
       };
 
-      // Shrink original + insert new frame
+      // Shrink original + insert new frame.
+      // IMPORTANT: keep contentFrames sorted by startFrame. The new (split) frame
+      // starts in the middle of the timeline, so appending it would leave the array
+      // unsorted whenever a later frame exists. getContentFrameAtTime() relies on a
+      // binary search over a sorted array — an unsorted array makes it miss the new
+      // frame, which renders blank and can't be drawn on. See bug: split corruption.
       set((state) => ({
         layers: updateLayer(state.layers, layerId, (l) => ({
           ...l,
-          contentFrames: l.contentFrames.map((c) =>
-            c.id === frameId
-              ? { ...c, durationFrames: leftDuration }
-              : c,
-          ).concat(newFrame),
+          contentFrames: l.contentFrames
+            .map((c) =>
+              c.id === frameId
+                ? { ...c, durationFrames: leftDuration }
+                : c,
+            )
+            .concat(newFrame)
+            .sort((a, b) => a.startFrame - b.startFrame),
         })),
       }));
 
@@ -1237,10 +1248,12 @@ export const useTimelineStore = create<TimelineState>()(
       // Auto-expand timeline if needed
       get().ensureTimelineContains(afterEnd + cf.durationFrames - 1);
 
+      // Keep contentFrames sorted by startFrame (the copy lands in a gap that may
+      // sit before later frames) so getContentFrameAtTime()'s binary search holds.
       set((state) => ({
         layers: updateLayer(state.layers, layerId, (l) => ({
           ...l,
-          contentFrames: [...l.contentFrames, newFrame],
+          contentFrames: [...l.contentFrames, newFrame].sort((a, b) => a.startFrame - b.startFrame),
         })),
       }));
 

--- a/src/utils/layerCompositing.ts
+++ b/src/utils/layerCompositing.ts
@@ -388,14 +388,16 @@ export function compositeLayersAtFrame(
  * Returns null if the frame falls in a gap between content frames.
  * 
  * PERF FIX: Uses binary search (O(log F)) instead of linear scan (O(F)).
- * Content frames are sorted by startFrame, so binary search is valid.
- * Falls back to linear scan if the array appears unsorted.
+ * Content frames are expected to be sorted by startFrame, so binary search is valid.
+ * Falls back to a linear scan if the binary search misses, which guarantees a
+ * correct result even if the array is momentarily unsorted (content frames never
+ * overlap, so at most one frame can contain a given time — there are no false hits).
  */
 export function getContentFrameAtTime(layer: Layer, frame: number): ContentFrame | null {
   const cfs = layer.contentFrames;
   if (cfs.length === 0) return null;
 
-  // Binary search: content frames are sorted by startFrame
+  // Binary search: content frames are expected to be sorted by startFrame
   let lo = 0;
   let hi = cfs.length - 1;
 
@@ -411,6 +413,16 @@ export function getContentFrameAtTime(layer: Layer, frame: number): ContentFrame
       // frame is within this content frame's range
       if (cf.hidden) return null;
       return cf;
+    }
+  }
+
+  // Fallback: if the array was not sorted by startFrame, the binary search above
+  // can incorrectly miss a frame that actually contains `frame`. A linear scan
+  // recovers it. Because content frames never overlap, this can only ever find the
+  // one correct frame (or nothing, for a genuine gap).
+  for (const cf of cfs) {
+    if (frame >= cf.startFrame && frame < cf.startFrame + cf.durationFrames) {
+      return cf.hidden ? null : cf;
     }
   }
 


### PR DESCRIPTION
## Why

Splitting a content frame sometimes produced a corrupted `(split)` frame: it rendered fully blank and could not be drawn on or edited. It was intermittent, which made it hard to pin down.

## Root cause

The split only broke when the frame being split had **another content frame positioned after it** on the same layer.

`splitContentFrame` appended the newly created frame to the **end** of the layer's `contentFrames` array, even though its `startFrame` sits in the *middle* of the timeline. That left the array out of `startFrame` order.

`getContentFrameAtTime()` (used by the canvas/frame-sync to find the content frame under the playhead) does a **binary search that assumes the array is sorted by `startFrame`**. Its code comment claimed a "linear scan fallback," but that fallback was never actually implemented. On an unsorted array the search missed the new frame and returned `null`, so the canvas had no frame to render or auto-save into. When the split frame happened to be the last frame on the layer, appending kept the array sorted and everything worked, hence the intermittent behavior.

## Approach

- Keep `contentFrames` sorted by `startFrame` at the clean insertion points: `splitContentFrame`, `addContentFrame`, and `duplicateContentFrame`. The latter two shared the same latent flaw (insert into a gap before later frames) and are also reachable via undo/redo and paste.
- Implement the real linear-scan fallback in `getContentFrameAtTime` as defense-in-depth. The fast binary search still handles the hot path; the fallback only runs on a miss and guarantees correctness for any transient unsorted state (for example during drag-reorder, which intentionally parks frames at intermediate positions). It is safe because content frames never overlap, so at most one frame can contain a given time.

## Testing

- Added 2 regression tests (unsorted lookup in `getContentFrameAtTime`, and split ordering/findability in the store). Confirmed both fail without the fix and pass with it.
- Full unit suite: 381/381 pass. `tsc` and `eslint` clean.