### PR TITLE
Preserve media import preview frame on setting edits

### DIFF
--- a/src/__tests__/importStorePreview.test.ts
+++ b/src/__tests__/importStorePreview.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Import Store Preview Tests
+ *
+ * Tests for src/stores/importStore.ts preview-frame behavior.
+ *
+ * Regression coverage: navigating the import preview to a specific frame must
+ * persist when a setting change re-processes the media frames. Previously
+ * `setProcessedFrames` always reset the preview to the first frame, snapping the
+ * user back to frame 0 on every property edit.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useImportStore } from '../stores/importStore';
+import type { ProcessedFrame } from '../utils/mediaProcessor';
+
+function makeFrame(): ProcessedFrame {
+  // The store only stores/relays frames; it never reads `canvas`/`imageData`,
+  // so a lightweight stub keeps the test focused on preview-index logic and
+  // avoids needing canvas/ImageData APIs that jsdom does not provide.
+  return { canvas: {} as HTMLCanvasElement, imageData: {} as ImageData };
+}
+
+function makeFrames(count: number): ProcessedFrame[] {
+  return Array.from({ length: count }, makeFrame);
+}
+
+describe('importStore preview frame index', () => {
+  beforeEach(() => {
+    useImportStore.setState({
+      selectedFile: null,
+      processedFrames: [],
+      previewFrameIndex: 0,
+      isPreviewMode: false,
+    });
+  });
+
+  it('starts at frame 0 when frames are first processed', () => {
+    useImportStore.getState().setProcessedFrames(makeFrames(10));
+    const state = useImportStore.getState();
+    expect(state.previewFrameIndex).toBe(0);
+    expect(state.isPreviewMode).toBe(true);
+  });
+
+  it('preserves the selected preview frame when frames are re-processed', () => {
+    const store = useImportStore.getState();
+    store.setProcessedFrames(makeFrames(10));
+    store.setPreviewFrameIndex(5);
+    expect(useImportStore.getState().previewFrameIndex).toBe(5);
+
+    // Simulate a setting change that re-extracts the same number of frames.
+    store.setProcessedFrames(makeFrames(10));
+    expect(useImportStore.getState().previewFrameIndex).toBe(5);
+  });
+
+  it('clamps the preserved frame to the new (shorter) frame range', () => {
+    const store = useImportStore.getState();
+    store.setProcessedFrames(makeFrames(10));
+    store.setPreviewFrameIndex(8);
+    expect(useImportStore.getState().previewFrameIndex).toBe(8);
+
+    store.setProcessedFrames(makeFrames(4));
+    expect(useImportStore.getState().previewFrameIndex).toBe(3);
+  });
+
+  it('resets to frame 0 when there are no frames', () => {
+    const store = useImportStore.getState();
+    store.setProcessedFrames(makeFrames(10));
+    store.setPreviewFrameIndex(5);
+
+    store.setProcessedFrames([]);
+    const state = useImportStore.getState();
+    expect(state.previewFrameIndex).toBe(0);
+    expect(state.isPreviewMode).toBe(false);
+  });
+
+  it('resets to frame 0 when a new file is selected, then keeps it through processing', () => {
+    const store = useImportStore.getState();
+    store.setProcessedFrames(makeFrames(10));
+    store.setPreviewFrameIndex(7);
+
+    // Selecting a new file should reset the preview position.
+    store.setSelectedFile(null);
+    expect(useImportStore.getState().previewFrameIndex).toBe(0);
+
+    // Processing the newly selected file keeps the reset position.
+    store.setProcessedFrames(makeFrames(10));
+    expect(useImportStore.getState().previewFrameIndex).toBe(0);
+  });
+});

--- a/src/stores/importStore.ts
+++ b/src/stores/importStore.ts
@@ -301,11 +301,19 @@ export const useImportStore = create<ImportState>((set, get) => ({
   },
   
   setProcessedFrames: (frames: ProcessedFrame[]) => {
-    set({ 
+    set((state) => ({ 
       processedFrames: frames,
-      previewFrameIndex: 0,
+      // Preserve the user's current preview position when frames are
+      // re-processed (e.g. a live-preview setting change re-extracts frames).
+      // The index is clamped to the new frame range. Selecting a new file or
+      // opening the modal resets the index to 0 via their own actions, so the
+      // only path that reaches here with a non-zero index is reprocessing the
+      // same media, where the chosen frame should persist.
+      previewFrameIndex: frames.length > 0
+        ? Math.max(0, Math.min(frames.length - 1, state.previewFrameIndex))
+        : 0,
       isPreviewMode: frames.length > 0
-    });
+    }));
   },
   
   setProcessing: (isProcessing: boolean) => {


### PR DESCRIPTION
## Why

When importing a video via Import Media, the preview controls let you navigate to any frame in the timeline. But editing a property during live preview snapped the preview back to the first frame, losing your position. The chosen preview frame should persist for the entire editing session.

## Root cause

Editing a structural setting (width, height, crop mode, character mapping style, sampling quality) re-extracts frames and calls `setProcessedFrames` in `importStore`. That action unconditionally reset `previewFrameIndex` to `0`, so every such edit jumped the preview back to frame 0.

## Approach

`setProcessedFrames` now preserves the current `previewFrameIndex`, clamped to the new frame range, instead of always resetting to 0. Selecting a new file and opening the modal still reset the index to 0 through their own actions (`setSelectedFile` / `openImportModal`), so the only path that reaches `setProcessedFrames` with a non-zero index is reprocessing the same media, where the chosen frame should persist.

Non-structural edits (brightness, contrast, color mapping, etc.) already preserved the frame since they only re-render the existing frame without re-extracting; this change closes the gap for the structural edits that did reprocess.

## Tests

Adds `src/__tests__/importStorePreview.test.ts` covering:
- fresh start lands on frame 0
- selected frame is preserved across reprocessing
- preserved frame is clamped when the new frame range is shorter
- empty frames reset to 0 and exit preview mode
- new-file selection resets to 0 and stays there through processing

Full suite: 386 passed. Lint and typecheck clean.