### PR TITLE
Acknowledge serialized MCP browser commands

### DIFF
--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -325,7 +325,7 @@ describe('MCPClient acknowledged commands', () => {
     const afterInactive = useTimelineStore.getState().layers[0];
     expect(inactiveResult).toMatchObject({
       success: true,
-      applied: { currentFrameIndex: 1, cellsChanged: 1 },
+      applied: { currentFrameIndex: 0, cellsChanged: 1 },
     });
     expect(afterInactive.contentFrames[1].data.get('1,0')).toEqual(cell('I'));
     expect(useCanvasStore.getState().cells.get('1,0')).toBeUndefined();
@@ -346,6 +346,37 @@ describe('MCPClient acknowledged commands', () => {
     });
     expect(useTimelineStore.getState().layers[0].contentFrames[0].data.get('2,0')).toEqual(cell('C'));
     expect(useCanvasStore.getState().cells.get('2,0')).toEqual(cell('C'));
+  });
+
+  it('reports the timeline playhead for a targetless batch', async () => {
+    const timeline = useTimelineStore.getState();
+    const layer = timeline.layers[0];
+    const firstFrame = layer.contentFrames[0];
+    timeline.setDuration(6);
+    expect(timeline.updateContentFrameTiming(layer.id, firstFrame.id, 0, 5)).toBe(true);
+    timeline.addContentFrame(layer.id, 5, 1, new Map([
+      ['0,0', cell('B')],
+    ]));
+    timeline.goToFrame(5);
+    useCanvasStore.getState().setActiveLayerId(layer.id);
+    useCanvasStore.getState().setCanvasData(new Map([['0,0', cell('B')]]));
+
+    const socket = await connected();
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'targetless-batch',
+      command: {
+        type: 'set_cells_batch',
+        cells: [{ x: 1, y: 0, cell: cell('T') }],
+      },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      applied: { currentFrameIndex: 5, cellsChanged: 1 },
+    });
+    expect(useTimelineStore.getState().layers[0].contentFrames[1].data.get('1,0')).toEqual(cell('T'));
+    expect(useCanvasStore.getState().cells.get('1,0')).toEqual(cell('T'));
   });
 
   it('returns one correlated failure without partially applying an invalid batch', async () => {

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -401,7 +401,7 @@ describe('MCPClient acknowledged commands', () => {
     });
   });
 
-  it('reflows later content frames and timeline duration for legacy frame duration changes', async () => {
+  it('reflows later frames and the playhead while preserving visible content', async () => {
     const timeline = useTimelineStore.getState();
     timeline.setFrameRate(10, false);
     const layer = timeline.layers[0];
@@ -409,8 +409,9 @@ describe('MCPClient acknowledged commands', () => {
     timeline.addContentFrame(layer.id, 2, 2, new Map([['0,0', cell('B')]]));
     timeline.addContentFrame(layer.id, 4, 2, new Map([['0,0', cell('C')]]));
     timeline.setDuration(6);
+    timeline.goToFrame(4);
     useCanvasStore.getState().setActiveLayerId(layer.id);
-    useCanvasStore.getState().setCanvasData(new Map([['0,0', cell('A')]]));
+    useCanvasStore.getState().setCanvasData(new Map([['0,0', cell('C')]]));
     const socket = await connected();
 
     const result = await sendCommand(socket, {
@@ -436,9 +437,41 @@ describe('MCPClient acknowledged commands', () => {
       durationFrames: 7,
       durationMs: 700,
     });
+    expect(applied.view.currentFrame).toBe(5);
+    expect(useCanvasStore.getState().cells.get('0,0')).toEqual(cell('C'));
     expect(result).toMatchObject({
       success: true,
-      applied: { currentFrameIndex: 0, durationMs: 300 },
+      applied: { currentFrameIndex: 5, durationMs: 300 },
+    });
+  });
+
+  it('clamps a playhead that falls beyond a shortened content frame', async () => {
+    const timeline = useTimelineStore.getState();
+    timeline.setFrameRate(10, false);
+    const layer = timeline.layers[0];
+    timeline.updateContentFrameTiming(layer.id, layer.contentFrames[0].id, 0, 3);
+    timeline.setDuration(3);
+    timeline.goToFrame(2);
+    useCanvasStore.getState().setActiveLayerId(layer.id);
+    useCanvasStore.getState().setCanvasData(new Map([['0,0', cell('A')]]));
+    const socket = await connected();
+
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'shorten-duration',
+      command: {
+        type: 'set_frame_duration',
+        index: 0,
+        duration: 100,
+      },
+    });
+
+    expect(useTimelineStore.getState().view.currentFrame).toBe(0);
+    expect(useTimelineStore.getState().config.durationFrames).toBe(1);
+    expect(useCanvasStore.getState().cells.get('0,0')).toEqual(cell('A'));
+    expect(result).toMatchObject({
+      success: true,
+      applied: { currentFrameIndex: 0, durationMs: 100 },
     });
   });
 
@@ -532,5 +565,95 @@ describe('MCPClient acknowledged commands', () => {
       success: false,
       error: 'Failed to import session: Unknown session file format',
     });
+  });
+
+  it('rejects malformed v2 data before mutating any project store', async () => {
+    const timeline = useTimelineStore.getState();
+    const layer = timeline.layers[0];
+    timeline.updateContentFrameData(layer.id, layer.contentFrames[0].id, new Map([
+      ['4,4', cell('O')],
+    ]));
+    useCanvasStore.setState({
+      width: 50,
+      height: 20,
+      cells: new Map([['4,4', cell('O')]]),
+      canvasBackgroundColor: '#303030',
+      showGrid: false,
+      activeLayerId: layer.id,
+      isDirty: false,
+    });
+    useProjectMetadataStore.setState({
+      projectName: 'Original Project',
+      projectDescription: 'Must survive a rejected load',
+      currentProjectId: 'original-project-id',
+    });
+
+    const before = {
+      metadata: {
+        projectName: useProjectMetadataStore.getState().projectName,
+        projectDescription: useProjectMetadataStore.getState().projectDescription,
+        currentProjectId: useProjectMetadataStore.getState().currentProjectId,
+      },
+      canvas: {
+        width: useCanvasStore.getState().width,
+        height: useCanvasStore.getState().height,
+        cells: Array.from(useCanvasStore.getState().cells.entries()),
+        canvasBackgroundColor: useCanvasStore.getState().canvasBackgroundColor,
+        showGrid: useCanvasStore.getState().showGrid,
+        activeLayerId: useCanvasStore.getState().activeLayerId,
+        isDirty: useCanvasStore.getState().isDirty,
+      },
+      timeline: useTimelineStore.getState().getSessionData(),
+      isImportingSession: useAnimationStore.getState().isImportingSession,
+    };
+
+    const mutation = vi.fn();
+    const unsubscribe = [
+      useProjectMetadataStore.subscribe(mutation),
+      useCanvasStore.subscribe(mutation),
+      useTimelineStore.subscribe(mutation),
+      useAnimationStore.subscribe(mutation),
+    ];
+
+    const malformed = makeV2Session();
+    (malformed.layers[0] as unknown as Record<string, unknown>).propertyTracks = undefined;
+
+    const socket = await connected();
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'load-malformed-v2',
+      command: {
+        type: 'load_project',
+        sessionData: malformed,
+      },
+    });
+
+    unsubscribe.forEach((unsubscribeStore) => unsubscribeStore());
+
+    expect(result).toEqual({
+      type: 'command_result',
+      requestId: 'load-malformed-v2',
+      success: false,
+      error: 'Failed to import session: Invalid v2 session: session.layers[0].propertyTracks must be an array',
+    });
+    expect(mutation).not.toHaveBeenCalled();
+    expect({
+      metadata: {
+        projectName: useProjectMetadataStore.getState().projectName,
+        projectDescription: useProjectMetadataStore.getState().projectDescription,
+        currentProjectId: useProjectMetadataStore.getState().currentProjectId,
+      },
+      canvas: {
+        width: useCanvasStore.getState().width,
+        height: useCanvasStore.getState().height,
+        cells: Array.from(useCanvasStore.getState().cells.entries()),
+        canvasBackgroundColor: useCanvasStore.getState().canvasBackgroundColor,
+        showGrid: useCanvasStore.getState().showGrid,
+        activeLayerId: useCanvasStore.getState().activeLayerId,
+        isDirty: useCanvasStore.getState().isDirty,
+      },
+      timeline: useTimelineStore.getState().getSessionData(),
+      isImportingSession: useAnimationStore.getState().isImportingSession,
+    }).toEqual(before);
   });
 });

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -1,0 +1,536 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCPClient } from '../mcp/client';
+import { MCPCommandDispatcher } from '../mcp/commandDispatcher';
+import { useMCPStore } from '../mcp/store';
+import type {
+  MCPCommandRequest,
+  MCPCommandResult,
+} from '../mcp/types';
+import { useAnimationStore } from '../stores/animationStore';
+import { useCanvasStore } from '../stores/canvasStore';
+import { useProjectMetadataStore } from '../stores/projectMetadataStore';
+import { useTimelineStore } from '../stores/timelineStore';
+import type { Cell } from '../types';
+import type { SessionDataV2 } from '../types/timeline';
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly sent: string[] = [];
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  receive(message: unknown): void {
+    this.onmessage?.(new MessageEvent('message', {
+      data: JSON.stringify(message),
+    }));
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+}
+
+function cell(char: string): Cell {
+  return {
+    char,
+    color: '#ffffff',
+    bgColor: '#000000',
+  };
+}
+
+function resetStores(): void {
+  useTimelineStore.getState().createNewProject();
+  useCanvasStore.setState({
+    width: 80,
+    height: 24,
+    cells: new Map(),
+    canvasBackgroundColor: '#000000',
+    showGrid: true,
+    activeLayerId: null,
+    isDirty: false,
+  });
+  useAnimationStore.setState({
+    isImportingSession: false,
+    selectedFrameIndices: new Set([0]),
+  });
+  useProjectMetadataStore.getState().resetProject();
+  useMCPStore.getState().reset();
+}
+
+function sentCommandResults(socket: MockWebSocket): MCPCommandResult[] {
+  return socket.sent
+    .map((message) => JSON.parse(message) as unknown)
+    .filter((message): message is MCPCommandResult => (
+      typeof message === 'object'
+      && message !== null
+      && 'type' in message
+      && message.type === 'command_result'
+    ));
+}
+
+async function connectClient(): Promise<{
+  client: MCPClient;
+  socket: MockWebSocket;
+}> {
+  const client = new MCPClient();
+  const connection = client.connect('test-token');
+  const socket = MockWebSocket.instances.at(-1);
+  if (!socket) {
+    throw new Error('MCPClient did not create a WebSocket');
+  }
+
+  socket.open();
+  await connection;
+  socket.sent.length = 0;
+  return { client, socket };
+}
+
+async function sendCommand(
+  socket: MockWebSocket,
+  request: MCPCommandRequest,
+): Promise<MCPCommandResult> {
+  socket.receive(request);
+
+  await vi.waitFor(() => {
+    expect(
+      sentCommandResults(socket).filter((result) => result.requestId === request.requestId),
+    ).toHaveLength(1);
+  });
+
+  return sentCommandResults(socket).find(
+    (result) => result.requestId === request.requestId,
+  )!;
+}
+
+function makeV1Session(): Record<string, unknown> {
+  return {
+    version: '1.0.0',
+    name: 'Loaded V1',
+    canvas: {
+      width: 40,
+      height: 20,
+      canvasBackgroundColor: '#101010',
+      showGrid: false,
+    },
+    animation: {
+      currentFrameIndex: 0,
+      frameRate: 10,
+      looping: true,
+      frames: [
+        {
+          id: 'v1-frame-1',
+          name: 'First',
+          duration: 100,
+          data: { '1,1': cell('V') },
+        },
+        {
+          id: 'v1-frame-2',
+          name: 'Second',
+          duration: 200,
+          data: { '2,2': cell('1') },
+        },
+      ],
+    },
+    tools: {
+      activeTool: 'pencil',
+      selectedColor: '#ffffff',
+    },
+  };
+}
+
+function makeV2Session(): SessionDataV2 {
+  return {
+    version: '2.0.0',
+    name: 'Loaded V2',
+    canvas: {
+      width: 60,
+      height: 30,
+      canvasBackgroundColor: '#202020',
+      showGrid: true,
+    },
+    timeline: {
+      frameRate: 24,
+      durationFrames: 4,
+      looping: false,
+    },
+    layers: [
+      {
+        id: 'loaded-layer',
+        name: 'Loaded Layer',
+        visible: true,
+        solo: false,
+        locked: false,
+        opacity: 100,
+        contentFrames: [
+          {
+            id: 'loaded-frame',
+            name: 'Loaded Frame',
+            startFrame: 0,
+            durationFrames: 4,
+            data: { '3,2': cell('2') },
+          },
+        ],
+        propertyTracks: [],
+      },
+    ],
+  };
+}
+
+describe('MCPCommandDispatcher', () => {
+  it('executes and emits command results strictly FIFO', async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const started: string[] = [];
+    const emitted: MCPCommandResult[] = [];
+    const dispatcher = new MCPCommandDispatcher(
+      async (command) => {
+        started.push(command.type);
+        if (command.type === 'load_project') {
+          await firstGate;
+        }
+        return command.type === 'set_frame_rate'
+          ? { frameRate: command.fps }
+          : undefined;
+      },
+      (result) => emitted.push(result),
+    );
+
+    const first = dispatcher.dispatch({
+      type: 'command_request',
+      requestId: 'first',
+      command: { type: 'load_project', sessionData: {} },
+    });
+    const second = dispatcher.dispatch({
+      type: 'command_request',
+      requestId: 'second',
+      command: { type: 'set_frame_rate', fps: 24 },
+    });
+    const malformed = dispatcher.reject('malformed', 'invalid command');
+
+    await Promise.resolve();
+    expect(started).toEqual(['load_project']);
+    expect(emitted).toEqual([]);
+
+    releaseFirst?.();
+    await Promise.all([first, second, malformed]);
+
+    expect(started).toEqual(['load_project', 'set_frame_rate']);
+    expect(emitted.map((result) => result.requestId)).toEqual([
+      'first',
+      'second',
+      'malformed',
+    ]);
+    expect(emitted[2]).toEqual({
+      type: 'command_result',
+      requestId: 'malformed',
+      success: false,
+      error: 'invalid command',
+    });
+  });
+
+  it('emits one correlated failure result when a handler throws', async () => {
+    const emitted: MCPCommandResult[] = [];
+    const dispatcher = new MCPCommandDispatcher(
+      () => {
+        throw new Error('invalid command payload');
+      },
+      (result) => emitted.push(result),
+    );
+
+    const result = await dispatcher.dispatch({
+      type: 'command_request',
+      requestId: 'failure-id',
+      command: { type: 'set_frame_rate', fps: 0 },
+    });
+
+    expect(result).toEqual({
+      type: 'command_result',
+      requestId: 'failure-id',
+      success: false,
+      error: 'invalid command payload',
+    });
+    expect(emitted).toEqual([result]);
+  });
+});
+
+describe('MCPClient acknowledged commands', () => {
+  const clients: MCPClient[] = [];
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    resetStores();
+  });
+
+  afterEach(() => {
+    for (const client of clients.splice(0)) {
+      client.disconnect();
+    }
+    vi.unstubAllGlobals();
+  });
+
+  async function connected(): Promise<MockWebSocket> {
+    const { client, socket } = await connectClient();
+    clients.push(client);
+    return socket;
+  }
+
+  it('writes targeted inactive and active content-frame batches', async () => {
+    const timeline = useTimelineStore.getState();
+    const layer = timeline.layers[0];
+    timeline.updateContentFrameData(layer.id, layer.contentFrames[0].id, new Map([
+      ['0,0', cell('A')],
+    ]));
+    timeline.addContentFrame(layer.id, 1, 1, new Map([
+      ['0,0', cell('B')],
+    ]));
+    timeline.goToFrame(0);
+    useCanvasStore.getState().setActiveLayerId(layer.id);
+    useCanvasStore.getState().setCanvasData(new Map([['0,0', cell('A')]]));
+
+    const socket = await connected();
+    const inactiveResult = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'inactive-batch',
+      command: {
+        type: 'set_cells_batch',
+        frameIndex: 1,
+        cells: [{ x: 1, y: 0, cell: cell('I') }],
+      },
+    });
+
+    const afterInactive = useTimelineStore.getState().layers[0];
+    expect(inactiveResult).toMatchObject({
+      success: true,
+      applied: { currentFrameIndex: 1, cellsChanged: 1 },
+    });
+    expect(afterInactive.contentFrames[1].data.get('1,0')).toEqual(cell('I'));
+    expect(useCanvasStore.getState().cells.get('1,0')).toBeUndefined();
+
+    const activeResult = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'active-batch',
+      command: {
+        type: 'set_cells_batch',
+        frameIndex: 0,
+        cells: [{ x: 2, y: 0, cell: cell('C') }],
+      },
+    });
+
+    expect(activeResult).toMatchObject({
+      success: true,
+      applied: { currentFrameIndex: 0, cellsChanged: 1 },
+    });
+    expect(useTimelineStore.getState().layers[0].contentFrames[0].data.get('2,0')).toEqual(cell('C'));
+    expect(useCanvasStore.getState().cells.get('2,0')).toEqual(cell('C'));
+  });
+
+  it('returns one correlated failure without partially applying an invalid batch', async () => {
+    const socket = await connected();
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'invalid-batch',
+      command: {
+        type: 'set_cells_batch',
+        frameIndex: 99,
+        cells: [{ x: 0, y: 0, cell: cell('X') }],
+      },
+    });
+
+    expect(result).toMatchObject({
+      requestId: 'invalid-batch',
+      success: false,
+    });
+    expect(sentCommandResults(socket).filter(
+      (entry) => entry.requestId === 'invalid-batch',
+    )).toHaveLength(1);
+    expect(useCanvasStore.getState().cells.size).toBe(0);
+  });
+
+  it('changes playback speed while preserving frame counts and timings', async () => {
+    const timeline = useTimelineStore.getState();
+    timeline.setDuration(12);
+    const beforeFrames = timeline.layers[0].contentFrames.map((frame) => ({
+      startFrame: frame.startFrame,
+      durationFrames: frame.durationFrames,
+    }));
+    const socket = await connected();
+
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'set-fps',
+      command: { type: 'set_frame_rate', fps: 24 },
+    });
+
+    const applied = useTimelineStore.getState();
+    expect(applied.config).toMatchObject({
+      frameRate: 24,
+      durationFrames: 12,
+      durationMs: 500,
+    });
+    expect(applied.layers[0].contentFrames.map((frame) => ({
+      startFrame: frame.startFrame,
+      durationFrames: frame.durationFrames,
+    }))).toEqual(beforeFrames);
+    expect(result).toMatchObject({
+      success: true,
+      applied: { frameRate: 24, durationMs: 500 },
+    });
+  });
+
+  it('reflows later content frames and timeline duration for legacy frame duration changes', async () => {
+    const timeline = useTimelineStore.getState();
+    timeline.setFrameRate(10, false);
+    const layer = timeline.layers[0];
+    timeline.updateContentFrameTiming(layer.id, layer.contentFrames[0].id, 0, 2);
+    timeline.addContentFrame(layer.id, 2, 2, new Map([['0,0', cell('B')]]));
+    timeline.addContentFrame(layer.id, 4, 2, new Map([['0,0', cell('C')]]));
+    timeline.setDuration(6);
+    useCanvasStore.getState().setActiveLayerId(layer.id);
+    useCanvasStore.getState().setCanvasData(new Map([['0,0', cell('A')]]));
+    const socket = await connected();
+
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'set-duration',
+      command: {
+        type: 'set_frame_duration',
+        index: 0,
+        duration: 300,
+      },
+    });
+
+    const applied = useTimelineStore.getState();
+    expect(applied.layers[0].contentFrames.map((frame) => ({
+      startFrame: frame.startFrame,
+      durationFrames: frame.durationFrames,
+    }))).toEqual([
+      { startFrame: 0, durationFrames: 3 },
+      { startFrame: 3, durationFrames: 2 },
+      { startFrame: 5, durationFrames: 2 },
+    ]);
+    expect(applied.config).toMatchObject({
+      durationFrames: 7,
+      durationMs: 700,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      applied: { currentFrameIndex: 0, durationMs: 300 },
+    });
+  });
+
+  it('rejects invalid frame durations without changing the sequence', async () => {
+    const before = useTimelineStore.getState().layers[0].contentFrames.map((frame) => ({
+      startFrame: frame.startFrame,
+      durationFrames: frame.durationFrames,
+    }));
+    const socket = await connected();
+
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'invalid-duration',
+      command: {
+        type: 'set_frame_duration',
+        index: 0,
+        duration: 0,
+      },
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(useTimelineStore.getState().layers[0].contentFrames.map((frame) => ({
+      startFrame: frame.startFrame,
+      durationFrames: frame.durationFrames,
+    }))).toEqual(before);
+  });
+
+  it('acknowledges a v1 project only after migrated stores and active canvas are installed', async () => {
+    const socket = await connected();
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'load-v1',
+      command: {
+        type: 'load_project',
+        sessionData: makeV1Session(),
+      },
+    });
+
+    const timeline = useTimelineStore.getState();
+    expect(result).toMatchObject({
+      success: true,
+      applied: { currentFrameIndex: 0, frameRate: 10, durationMs: 300 },
+    });
+    expect(timeline.layers[0].contentFrames).toHaveLength(2);
+    expect(useProjectMetadataStore.getState().projectName).toBe('Loaded V1');
+    expect(useCanvasStore.getState().cells.get('1,1')).toEqual(cell('V'));
+    expect(useAnimationStore.getState().isImportingSession).toBe(false);
+  });
+
+  it('acknowledges a v2 project only after stores and active canvas are installed', async () => {
+    const socket = await connected();
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'load-v2',
+      command: {
+        type: 'load_project',
+        sessionData: makeV2Session(),
+      },
+    });
+
+    const timeline = useTimelineStore.getState();
+    expect(result).toMatchObject({
+      success: true,
+      applied: {
+        currentFrameIndex: 0,
+        frameRate: 24,
+        durationMs: 1000 / 6,
+      },
+    });
+    expect(timeline.layers[0].id).toBe('loaded-layer');
+    expect(useProjectMetadataStore.getState().projectName).toBe('Loaded V2');
+    expect(useCanvasStore.getState().cells.get('3,2')).toEqual(cell('2'));
+    expect(useCanvasStore.getState().activeLayerId).toBe('loaded-layer');
+    expect(useAnimationStore.getState().isImportingSession).toBe(false);
+  });
+
+  it('returns a correlated load failure for unsupported project data', async () => {
+    const socket = await connected();
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'load-invalid',
+      command: {
+        type: 'load_project',
+        sessionData: {},
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'command_result',
+      requestId: 'load-invalid',
+      success: false,
+      error: 'Failed to import session: Unknown session file format',
+    });
+  });
+});

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1152,7 +1152,7 @@ export class MCPClient {
     }
 
     return {
-      currentFrameIndex: targetFrameIndex,
+      currentFrameIndex: timeline.view.currentFrame,
       cellsChanged,
     };
   }

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -13,12 +13,28 @@ import { useSelectionStore } from '../stores/selectionStore';
 import { useProjectMetadataStore } from '../stores/projectMetadataStore';
 import { useTimelineStore } from '../stores/timelineStore';
 import { getContentFrameAtTime } from '../utils/layerCompositing';
+import { SessionImporter } from '../utils/sessionImporter';
+import { MCPCommandDispatcher } from './commandDispatcher';
 import { useMCPStore } from './store';
-import type { MCPCommand, MCPServerMessage, MCPClientAuth, MCPClientHeartbeat, MCPClientStateSnapshot, MCPExportRequest, MCPExportResult } from './types';
+import type {
+  MCPClientAuth,
+  MCPClientHeartbeat,
+  MCPClientStateSnapshot,
+  MCPCommand,
+  MCPCommandApplied,
+  MCPCommandRequest,
+  MCPExportRequest,
+  MCPExportResult,
+  MCPServerMessage,
+} from './types';
 
 const DEFAULT_PORT = 9876;
 const HEARTBEAT_INTERVAL = 30000; // 30 seconds
 const RECONNECT_DELAY = 3000; // 3 seconds
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
 
 export class MCPClient {
   private ws: WebSocket | null = null;
@@ -30,9 +46,14 @@ export class MCPClient {
   private autoReconnect: boolean = true;
   // Maps MCP server effect block IDs → browser effect block IDs
   private effectBlockIdMap: Map<string, string> = new Map();
+  private readonly commandDispatcher: MCPCommandDispatcher;
 
   constructor() {
     this.sessionId = this.generateSessionId();
+    this.commandDispatcher = new MCPCommandDispatcher(
+      (command) => this.executeCommand(command),
+      (result) => this.send(result),
+    );
   }
 
   /**
@@ -318,6 +339,20 @@ export class MCPClient {
     timeline.updateContentFrameData(activeLayer.id, cf.id, new Map(cells));
   }
 
+  private syncCanvasToCurrentContentFrame(): void {
+    const timeline = useTimelineStore.getState();
+    const activeLayer = timeline.layers.find((layer) => layer.id === timeline.view.activeLayerId)
+      ?? timeline.layers[0];
+    const activeFrame = activeLayer
+      ? getContentFrameAtTime(activeLayer, timeline.view.currentFrame)
+      : null;
+    const canvas = useCanvasStore.getState();
+
+    canvas.setActiveLayerId(activeLayer?.id ?? null);
+    canvas.setCanvasData(activeFrame ? new Map(activeFrame.data) : new Map<string, Cell>());
+    canvas.setDirty(false);
+  }
+
   private generateSessionId(): string {
     const timestamp = Date.now();
 
@@ -403,16 +438,25 @@ export class MCPClient {
 
   private handleMessage(data: string): void {
     try {
-      const message = JSON.parse(data);
+      const message: unknown = JSON.parse(data);
+
+      if (!isRecord(message)) {
+        throw new Error('MCP message must be an object');
+      }
       
       // Handle JSON-RPC style notifications from MCP server
-      if (message.jsonrpc === '2.0' && message.method) {
+      if (message.jsonrpc === '2.0' && typeof message.method === 'string') {
         this.handleNotification(message.method, message.params);
+        return;
+      }
+
+      if (message.type === 'command_request') {
+        this.handleCommandRequest(message);
         return;
       }
       
       // Handle legacy message format
-      const legacyMessage = message as MCPServerMessage;
+      const legacyMessage = message as unknown as MCPServerMessage;
       
       switch (legacyMessage.type) {
         case 'auth_result':
@@ -425,8 +469,10 @@ export class MCPClient {
           
         case 'command':
           if (legacyMessage.command) {
-            this.executeCommand(legacyMessage.command);
-            useMCPStore.getState().incrementCommandCount();
+            void this.executeCommand(legacyMessage.command).then(
+              () => useMCPStore.getState().incrementCommandCount(),
+              (error) => console.error('[MCP] Legacy command failed:', error),
+            );
           }
           break;
           
@@ -445,6 +491,34 @@ export class MCPClient {
     } catch (error) {
       console.error('[MCP] Failed to parse message:', error);
     }
+  }
+
+  private handleCommandRequest(message: Record<string, unknown>): void {
+    const requestId = message.requestId;
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      console.error('[MCP] command_request is missing a requestId');
+      return;
+    }
+
+    const command = message.command;
+    if (!isRecord(command) || typeof command.type !== 'string') {
+      void this.commandDispatcher.reject(
+        requestId,
+        'command_request is missing a valid command',
+      ).catch((error) => console.error('[MCP] Failed to emit command result:', error));
+      return;
+    }
+
+    const request: MCPCommandRequest = {
+      type: 'command_request',
+      requestId,
+      command: command as unknown as MCPCommand,
+    };
+
+    void this.commandDispatcher.dispatch(request).then(
+      () => useMCPStore.getState().incrementCommandCount(),
+      (error) => console.error('[MCP] Failed to emit command result:', error),
+    );
   }
 
   private handleNotification(method: string, params: unknown): void {
@@ -869,7 +943,7 @@ export class MCPClient {
     }
   }
 
-  private executeCommand(command: MCPCommand): void {
+  private async executeCommand(command: MCPCommand): Promise<MCPCommandApplied | undefined> {
     console.log('[MCP] Executing command:', command.type);
     
     switch (command.type) {
@@ -878,8 +952,7 @@ export class MCPClient {
         break;
         
       case 'set_cells_batch':
-        this.handleSetCellsBatch(command);
-        break;
+        return this.handleSetCellsBatch(command);
         
       case 'clear_cell':
         this.handleClearCell(command);
@@ -906,8 +979,10 @@ export class MCPClient {
         break;
         
       case 'set_frame_duration':
-        this.handleSetFrameDuration(command);
-        break;
+        return this.handleSetFrameDuration(command);
+
+      case 'set_frame_rate':
+        return this.handleSetFrameRate(command);
         
       case 'set_frame_data':
         this.handleSetFrameData(command);
@@ -926,8 +1001,7 @@ export class MCPClient {
         break;
         
       case 'load_project':
-        this.handleLoadProject(command);
-        break;
+        return this.handleLoadProject(command);
         
       case 'set_foreground_color':
         this.handleSetForegroundColor(command);
@@ -975,7 +1049,7 @@ export class MCPClient {
         break;
         
       default:
-        console.warn('[MCP] Unknown command type:', (command as { type: string }).type);
+        throw new Error(`Unsupported browser command: ${(command as { type: string }).type}`);
     }
   }
 
@@ -987,11 +1061,100 @@ export class MCPClient {
     useCanvasStore.getState().setCell(cmd.x, cmd.y, cmd.cell);
   }
 
-  private handleSetCellsBatch(cmd: { cells: Array<{ x: number; y: number; cell: Cell }> }): void {
-    const canvasStore = useCanvasStore.getState();
-    for (const { x, y, cell } of cmd.cells) {
-      canvasStore.setCell(x, y, cell);
+  private handleSetCellsBatch(cmd: {
+    cells: Array<{ x: number; y: number; cell: Cell }>;
+    frameIndex?: number;
+  }): MCPCommandApplied {
+    if (!Array.isArray(cmd.cells)) {
+      throw new Error('set_cells_batch cells must be an array');
     }
+
+    const canvas = useCanvasStore.getState();
+    for (const update of cmd.cells) {
+      if (
+        !isRecord(update)
+        || !Number.isInteger(update.x)
+        || !Number.isInteger(update.y)
+        || update.x < 0
+        || update.x >= canvas.width
+        || update.y < 0
+        || update.y >= canvas.height
+        || !isRecord(update.cell)
+        || typeof update.cell.char !== 'string'
+        || typeof update.cell.color !== 'string'
+        || typeof update.cell.bgColor !== 'string'
+      ) {
+        throw new Error('set_cells_batch contains an invalid or out-of-bounds cell');
+      }
+    }
+
+    if (cmd.frameIndex !== undefined && (!Number.isInteger(cmd.frameIndex) || cmd.frameIndex < 0)) {
+      throw new Error('set_cells_batch frameIndex must be a non-negative integer');
+    }
+
+    this.flushCanvasToActiveContentFrame();
+
+    const timeline = useTimelineStore.getState();
+    const activeLayer = timeline.layers.find((layer) => layer.id === timeline.view.activeLayerId)
+      ?? timeline.layers[0];
+    if (!activeLayer) {
+      throw new Error('set_cells_batch requires an active layer');
+    }
+
+    let targetFrameIndex = cmd.frameIndex;
+    if (targetFrameIndex === undefined) {
+      const currentContentFrame = getContentFrameAtTime(activeLayer, timeline.view.currentFrame);
+      targetFrameIndex = currentContentFrame
+        ? activeLayer.contentFrames.findIndex((frame) => frame.id === currentContentFrame.id)
+        : -1;
+    }
+
+    const targetFrame = activeLayer.contentFrames[targetFrameIndex];
+    if (!targetFrame) {
+      throw new Error(`set_cells_batch frameIndex ${targetFrameIndex} is out of range`);
+    }
+
+    const nextData = new Map(targetFrame.data);
+    let cellsChanged = 0;
+
+    for (const { x, y, cell } of cmd.cells) {
+      const key = `${x},${y}`;
+      const previous = nextData.get(key);
+      const removesCell = cell.char === ' '
+        && cell.color === '#FFFFFF'
+        && cell.bgColor === 'transparent';
+
+      if (removesCell) {
+        if (nextData.delete(key)) {
+          cellsChanged += 1;
+        }
+        continue;
+      }
+
+      if (
+        !previous
+        || previous.char !== cell.char
+        || previous.color !== cell.color
+        || previous.bgColor !== cell.bgColor
+      ) {
+        nextData.set(key, { ...cell });
+        cellsChanged += 1;
+      }
+    }
+
+    timeline.updateContentFrameData(activeLayer.id, targetFrame.id, nextData);
+
+    const currentContentFrame = getContentFrameAtTime(activeLayer, timeline.view.currentFrame);
+    if (currentContentFrame?.id === targetFrame.id) {
+      canvas.setActiveLayerId(activeLayer.id);
+      canvas.setCanvasData(nextData);
+      canvas.setDirty(false);
+    }
+
+    return {
+      currentFrameIndex: targetFrameIndex,
+      cellsChanged,
+    };
   }
 
   private handleClearCell(cmd: { x: number; y: number }): void {
@@ -1029,8 +1192,117 @@ export class MCPClient {
     useAnimationStore.getState().goToFrame(cmd.index);
   }
 
-  private handleSetFrameDuration(cmd: { index: number; duration: number }): void {
-    useAnimationStore.getState().updateFrameDuration(cmd.index, cmd.duration);
+  private handleSetFrameDuration(cmd: { index: number; duration: number }): MCPCommandApplied {
+    if (!Number.isInteger(cmd.index) || cmd.index < 0) {
+      throw new Error('set_frame_duration index must be a non-negative integer');
+    }
+    if (!Number.isFinite(cmd.duration) || cmd.duration <= 0) {
+      throw new Error('set_frame_duration duration must be greater than zero');
+    }
+
+    this.flushCanvasToActiveContentFrame();
+
+    const timeline = useTimelineStore.getState();
+    const activeLayer = timeline.layers.find((layer) => layer.id === timeline.view.activeLayerId)
+      ?? timeline.layers[0];
+    if (!activeLayer) {
+      throw new Error('set_frame_duration requires an active layer');
+    }
+
+    const targetFrame = activeLayer.contentFrames[cmd.index];
+    if (!targetFrame) {
+      throw new Error(`set_frame_duration index ${cmd.index} is out of range`);
+    }
+
+    const durationFrames = Math.round(cmd.duration / (1000 / timeline.config.frameRate));
+    if (!Number.isSafeInteger(durationFrames) || durationFrames < 1) {
+      throw new Error('set_frame_duration does not map to a valid timeline duration');
+    }
+
+    const delta = durationFrames - targetFrame.durationFrames;
+    const nextContentFrames = activeLayer.contentFrames.map((frame, index) => {
+      if (index < cmd.index) {
+        return frame;
+      }
+      if (index === cmd.index) {
+        return { ...frame, durationFrames };
+      }
+      return { ...frame, startFrame: frame.startFrame + delta };
+    });
+
+    let previousEnd = 0;
+    for (const [index, frame] of nextContentFrames.entries()) {
+      if (
+        !Number.isSafeInteger(frame.startFrame)
+        || !Number.isSafeInteger(frame.durationFrames)
+        || frame.startFrame < 0
+        || frame.durationFrames < 1
+        || (index > 0 && frame.startFrame < previousEnd)
+      ) {
+        throw new Error('set_frame_duration would create invalid or overlapping content frames');
+      }
+      previousEnd = frame.startFrame + frame.durationFrames;
+    }
+
+    const nextTimelineDuration = timeline.config.durationFrames + delta;
+    const otherLayerEnd = timeline.layers
+      .filter((layer) => layer.id !== activeLayer.id)
+      .flatMap((layer) => layer.contentFrames)
+      .reduce(
+        (maxEnd, frame) => Math.max(maxEnd, frame.startFrame + frame.durationFrames),
+        0,
+      );
+    const activeLayerEnd = nextContentFrames.reduce(
+      (maxEnd, frame) => Math.max(maxEnd, frame.startFrame + frame.durationFrames),
+      0,
+    );
+
+    if (
+      !Number.isSafeInteger(nextTimelineDuration)
+      || nextTimelineDuration < 1
+      || activeLayerEnd > nextTimelineDuration
+      || otherLayerEnd > nextTimelineDuration
+    ) {
+      throw new Error('set_frame_duration would create an invalid timeline duration');
+    }
+
+    useTimelineStore.setState((state) => ({
+      layers: state.layers.map((layer) => (
+        layer.id === activeLayer.id
+          ? { ...layer, contentFrames: nextContentFrames }
+          : layer
+      )),
+      config: {
+        ...state.config,
+        durationFrames: nextTimelineDuration,
+        durationMs: (nextTimelineDuration / state.config.frameRate) * 1000,
+      },
+    }));
+
+    this.syncCanvasToCurrentContentFrame();
+
+    return {
+      currentFrameIndex: cmd.index,
+      durationMs: durationFrames * (1000 / timeline.config.frameRate),
+    };
+  }
+
+  private handleSetFrameRate(cmd: { fps: number }): MCPCommandApplied {
+    if (!Number.isFinite(cmd.fps) || cmd.fps <= 0) {
+      throw new Error('set_frame_rate fps must be greater than zero');
+    }
+
+    useTimelineStore.getState().setFrameRate(cmd.fps, false);
+    const applied = useTimelineStore.getState().config;
+
+    if (applied.frameRate !== cmd.fps) {
+      throw new Error(`set_frame_rate failed to apply ${cmd.fps} fps`);
+    }
+
+    return {
+      frameRate: applied.frameRate,
+      durationMs: applied.durationMs,
+    };
   }
 
   private handleSetFrameData(cmd: { index: number; cells: Array<{ key: string; cell: Cell }> }): void {
@@ -1073,11 +1345,15 @@ export class MCPClient {
     useSelectionStore.getState().clearSelection();
   }
 
-  private handleLoadProject(_cmd: { sessionData: unknown }): void {
-    // This would need to integrate with the session importer
-    // For now, log a warning
-    console.warn('[MCP] load_project command received, but session import is not yet implemented in MCP client');
-    // TODO: Integrate with sessionImporter.ts
+  private async handleLoadProject(cmd: { sessionData: unknown }): Promise<MCPCommandApplied> {
+    await SessionImporter.importSessionData(cmd.sessionData);
+
+    const timeline = useTimelineStore.getState();
+    return {
+      currentFrameIndex: timeline.view.currentFrame,
+      frameRate: timeline.config.frameRate,
+      durationMs: timeline.config.durationMs,
+    };
   }
 
   private handleSetForegroundColor(cmd: { color: string }): void {

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1266,6 +1266,20 @@ export class MCPClient {
       throw new Error('set_frame_duration would create an invalid timeline duration');
     }
 
+    const oldTargetEnd = targetFrame.startFrame + targetFrame.durationFrames;
+    const newTargetEnd = targetFrame.startFrame + durationFrames;
+    let nextCurrentFrame = timeline.view.currentFrame;
+
+    if (nextCurrentFrame >= oldTargetEnd) {
+      nextCurrentFrame += delta;
+    } else if (nextCurrentFrame >= newTargetEnd) {
+      nextCurrentFrame = newTargetEnd - 1;
+    }
+    nextCurrentFrame = Math.max(
+      0,
+      Math.min(nextCurrentFrame, nextTimelineDuration - 1),
+    );
+
     useTimelineStore.setState((state) => ({
       layers: state.layers.map((layer) => (
         layer.id === activeLayer.id
@@ -1277,12 +1291,16 @@ export class MCPClient {
         durationFrames: nextTimelineDuration,
         durationMs: (nextTimelineDuration / state.config.frameRate) * 1000,
       },
+      view: {
+        ...state.view,
+        currentFrame: nextCurrentFrame,
+      },
     }));
 
     this.syncCanvasToCurrentContentFrame();
 
     return {
-      currentFrameIndex: cmd.index,
+      currentFrameIndex: nextCurrentFrame,
       durationMs: durationFrames * (1000 / timeline.config.frameRate),
     };
   }

--- a/src/mcp/commandDispatcher.ts
+++ b/src/mcp/commandDispatcher.ts
@@ -1,0 +1,100 @@
+import type {
+  MCPCommand,
+  MCPCommandApplied,
+  MCPCommandRequest,
+  MCPCommandResult,
+} from './types';
+
+export type MCPCommandExecutor = (
+  command: MCPCommand,
+) => Promise<MCPCommandApplied | undefined> | MCPCommandApplied | undefined;
+
+export type MCPCommandResultSender = (result: MCPCommandResult) => void;
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  const message = String(error);
+  return message === 'undefined' ? 'Unknown browser command error' : message;
+}
+
+/**
+ * Serializes authoritative server commands so state mutations and their
+ * correlated results are observed in exactly the order they were received.
+ */
+export class MCPCommandDispatcher {
+  private queue: Promise<void> = Promise.resolve();
+  private readonly execute: MCPCommandExecutor;
+  private readonly sendResult: MCPCommandResultSender;
+
+  constructor(
+    execute: MCPCommandExecutor,
+    sendResult: MCPCommandResultSender,
+  ) {
+    this.execute = execute;
+    this.sendResult = sendResult;
+  }
+
+  dispatch(request: MCPCommandRequest): Promise<MCPCommandResult> {
+    return this.enqueue(() => this.executeRequest(request));
+  }
+
+  reject(requestId: string, error: string): Promise<MCPCommandResult> {
+    return this.enqueue(() => {
+      const result: MCPCommandResult = {
+        type: 'command_result',
+        requestId,
+        success: false,
+        error,
+      };
+      this.sendResult(result);
+      return Promise.resolve(result);
+    });
+  }
+
+  private enqueue(
+    execute: () => Promise<MCPCommandResult>,
+  ): Promise<MCPCommandResult> {
+    const execution = this.queue.then(execute);
+    // Keep later commands moving even if the transport throws while emitting a
+    // result. The returned promise still exposes that transport failure.
+    this.queue = execution.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return execution;
+  }
+
+  private async executeRequest(request: MCPCommandRequest): Promise<MCPCommandResult> {
+    let result: MCPCommandResult;
+
+    try {
+      const applied = await this.execute(request.command);
+      result = applied
+        ? {
+            type: 'command_result',
+            requestId: request.requestId,
+            success: true,
+            applied,
+          }
+        : {
+            type: 'command_result',
+            requestId: request.requestId,
+            success: true,
+          };
+    } catch (error) {
+      result = {
+        type: 'command_result',
+        requestId: request.requestId,
+        success: false,
+        error: getErrorMessage(error),
+      };
+    }
+
+    this.sendResult(result);
+    return result;
+  }
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -27,6 +27,14 @@
  */
 
 export { MCPClient, createMCPClient } from './client';
+export { MCPCommandDispatcher } from './commandDispatcher';
 export { useMCPStore, type MCPConnectionState } from './store';
 export { useMCPConnection } from './useMCPConnection';
-export type { MCPCommand, MCPStateUpdate, MCPMessage } from './types';
+export type {
+  MCPCommand,
+  MCPCommandApplied,
+  MCPCommandRequest,
+  MCPCommandResult,
+  MCPStateUpdate,
+  MCPMessage,
+} from './types';

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -19,6 +19,7 @@ export type MCPCommand =
   | MCPDeleteFrameCommand
   | MCPGoToFrameCommand
   | MCPSetFrameDurationCommand
+  | MCPSetFrameRateCommand
   | MCPSetFrameDataCommand
   | MCPUndoCommand
   | MCPRedoCommand
@@ -46,6 +47,7 @@ export interface MCPSetCellCommand {
 export interface MCPSetCellsBatchCommand {
   type: 'set_cells_batch';
   cells: Array<{ x: number; y: number; cell: Cell }>;
+  frameIndex?: number;
 }
 
 export interface MCPClearCellCommand {
@@ -86,6 +88,11 @@ export interface MCPSetFrameDurationCommand {
   type: 'set_frame_duration';
   index: number;
   duration: number;
+}
+
+export interface MCPSetFrameRateCommand {
+  type: 'set_frame_rate';
+  fps: number;
 }
 
 export interface MCPSetFrameDataCommand {
@@ -213,7 +220,8 @@ export interface MCPMessage {
 export type MCPClientMessage =
   | MCPClientAuth
   | MCPClientHeartbeat
-  | MCPClientStateSnapshot;
+  | MCPClientStateSnapshot
+  | MCPCommandResult;
 
 export interface MCPClientAuth {
   type: 'auth';
@@ -287,10 +295,40 @@ export interface MCPExportResult {
 }
 
 /**
+ * Authoritative acknowledged command request sent by the MCP server.
+ */
+export interface MCPCommandRequest {
+  type: 'command_request';
+  requestId: string;
+  command: MCPCommand;
+}
+
+export interface MCPCommandApplied {
+  currentFrameIndex?: number;
+  cellsChanged?: number;
+  frameRate?: number;
+  durationMs?: number;
+}
+
+export type MCPCommandResult =
+  | {
+      type: 'command_result';
+      requestId: string;
+      success: true;
+      applied?: MCPCommandApplied;
+    }
+  | {
+      type: 'command_result';
+      requestId: string;
+      success: false;
+      error: string;
+    };
+
+/**
  * Server responses
  */
 export interface MCPServerMessage {
-  type: 'auth_result' | 'command' | 'state_request' | 'export_request' | 'error';
+  type: 'auth_result' | 'command' | 'command_request' | 'state_request' | 'export_request' | 'error';
   success?: boolean;
   error?: string;
   command?: MCPCommand;

--- a/src/utils/sessionImporter.ts
+++ b/src/utils/sessionImporter.ts
@@ -85,6 +85,442 @@ interface InstalledSessionCanvas {
   cells: Map<string, Cell>;
 }
 
+const VALID_TOOLS = new Set<Tool>([
+  'pencil',
+  'eraser',
+  'paintbucket',
+  'select',
+  'lasso',
+  'magicwand',
+  'rectangle',
+  'ellipse',
+  'eyedropper',
+  'line',
+  'text',
+  'asciitype',
+  'asciibox',
+  'brush',
+  'beziershape',
+  'gradientfill',
+  'fliphorizontal',
+  'flipvertical',
+  'layertransform',
+]);
+
+const VALID_MAPPING_METHODS = new Set<CharacterMappingSettings['mappingMethod']>([
+  'brightness',
+  'luminance',
+  'contrast',
+  'edge-detection',
+  'saturation',
+  'red-channel',
+  'green-channel',
+  'blue-channel',
+]);
+
+function invalidSession(path: string, expectation: string): never {
+  throw new Error(`Invalid v2 session: ${path} ${expectation}`);
+}
+
+function requireRecord(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    invalidSession(path, 'must be an object');
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) {
+    invalidSession(path, 'must be an array');
+  }
+  return value;
+}
+
+function requireString(value: unknown, path: string): string {
+  if (typeof value !== 'string') {
+    invalidSession(path, 'must be a string');
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') {
+    invalidSession(path, 'must be a boolean');
+  }
+  return value;
+}
+
+function requireFiniteNumber(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    invalidSession(path, 'must be a finite number');
+  }
+  return value;
+}
+
+function requireFrameNumber(value: unknown, path: string, minimum: number): number {
+  const frame = requireFiniteNumber(value, path);
+  if (!Number.isSafeInteger(frame) || frame < minimum) {
+    invalidSession(path, `must be an integer >= ${minimum}`);
+  }
+  return frame;
+}
+
+function validateOptionalString(
+  record: Record<string, unknown>,
+  property: string,
+  path: string,
+): void {
+  if (record[property] !== undefined) {
+    requireString(record[property], `${path}.${property}`);
+  }
+}
+
+function validateOptionalBoolean(
+  record: Record<string, unknown>,
+  property: string,
+  path: string,
+): void {
+  if (record[property] !== undefined) {
+    requireBoolean(record[property], `${path}.${property}`);
+  }
+}
+
+function validateEasing(value: unknown, path: string): void {
+  const easing = requireRecord(value, path);
+  requireString(easing.type, `${path}.type`);
+  for (const property of ['x1', 'y1', 'x2', 'y2']) {
+    if (easing[property] !== undefined) {
+      requireFiniteNumber(easing[property], `${path}.${property}`);
+    }
+  }
+}
+
+function validateKeyframe(
+  value: unknown,
+  path: string,
+  allowStringRecord: boolean,
+): void {
+  const keyframe = requireRecord(value, path);
+  requireString(keyframe.id, `${path}.id`);
+  requireFrameNumber(keyframe.frame, `${path}.frame`, 0);
+
+  const keyframeValue = keyframe.value;
+  const primitiveValue = typeof keyframeValue === 'string'
+    || typeof keyframeValue === 'boolean'
+    || (typeof keyframeValue === 'number' && Number.isFinite(keyframeValue));
+  const stringRecordValue = allowStringRecord
+    && typeof keyframeValue === 'object'
+    && keyframeValue !== null
+    && !Array.isArray(keyframeValue)
+    && Object.values(keyframeValue).every((entry) => typeof entry === 'string');
+  if (!primitiveValue && !stringRecordValue) {
+    invalidSession(`${path}.value`, 'has an unsupported value');
+  }
+
+  validateEasing(keyframe.easing, `${path}.easing`);
+}
+
+function validatePropertyTrack(
+  value: unknown,
+  path: string,
+  allowStringRecord: boolean,
+): void {
+  const track = requireRecord(value, path);
+  requireString(track.id, `${path}.id`);
+  requireString(track.propertyPath, `${path}.propertyPath`);
+  requireBoolean(track.loopKeyframes, `${path}.loopKeyframes`);
+  requireArray(track.keyframes, `${path}.keyframes`).forEach((keyframe, index) => {
+    validateKeyframe(keyframe, `${path}.keyframes[${index}]`, allowStringRecord);
+  });
+}
+
+function validateEffectTrack(value: unknown, path: string): void {
+  const track = requireRecord(value, path);
+  requireString(track.id, `${path}.id`);
+  if (track.ownerId !== null) {
+    requireString(track.ownerId, `${path}.ownerId`);
+  }
+  requireBoolean(track.collapsed, `${path}.collapsed`);
+
+  const block = requireRecord(track.effectBlock, `${path}.effectBlock`);
+  requireString(block.id, `${path}.effectBlock.id`);
+  requireString(block.effectType, `${path}.effectBlock.effectType`);
+  requireFrameNumber(block.startFrame, `${path}.effectBlock.startFrame`, 0);
+  requireFrameNumber(block.durationFrames, `${path}.effectBlock.durationFrames`, 1);
+  requireBoolean(block.enabled, `${path}.effectBlock.enabled`);
+  requireRecord(block.settings, `${path}.effectBlock.settings`);
+  requireArray(block.propertyTracks, `${path}.effectBlock.propertyTracks`).forEach(
+    (propertyTrack, index) => {
+      validatePropertyTrack(
+        propertyTrack,
+        `${path}.effectBlock.propertyTracks[${index}]`,
+        true,
+      );
+    },
+  );
+}
+
+function validatePostEffectTrack(value: unknown, path: string): void {
+  const track = requireRecord(value, path);
+  requireString(track.id, `${path}.id`);
+  requireBoolean(track.collapsed, `${path}.collapsed`);
+
+  const block = requireRecord(track.effectBlock, `${path}.effectBlock`);
+  requireString(block.id, `${path}.effectBlock.id`);
+  requireString(block.postEffectType, `${path}.effectBlock.postEffectType`);
+  requireFrameNumber(block.startFrame, `${path}.effectBlock.startFrame`, 0);
+  requireFrameNumber(block.durationFrames, `${path}.effectBlock.durationFrames`, 1);
+  requireBoolean(block.enabled, `${path}.effectBlock.enabled`);
+  requireRecord(block.settings, `${path}.effectBlock.settings`);
+  requireArray(block.propertyTracks, `${path}.effectBlock.propertyTracks`).forEach(
+    (propertyTrack, index) => {
+      validatePropertyTrack(
+        propertyTrack,
+        `${path}.effectBlock.propertyTracks[${index}]`,
+        false,
+      );
+    },
+  );
+}
+
+function validateStaticProperties(value: unknown, path: string): void {
+  const properties = requireRecord(value, path);
+  for (const [property, propertyValue] of Object.entries(properties)) {
+    requireFiniteNumber(propertyValue, `${path}.${property}`);
+  }
+}
+
+function validateSessionDataV2ForImport(value: unknown): asserts value is SessionDataV2 {
+  const session = requireRecord(value, 'session');
+  if (session.version !== '2.0.0' && session.version !== '2.1.0') {
+    invalidSession('session.version', 'must be 2.0.0 or 2.1.0');
+  }
+  validateOptionalString(session, 'name', 'session');
+  validateOptionalString(session, 'description', 'session');
+
+  const canvas = requireRecord(session.canvas, 'session.canvas');
+  requireFrameNumber(canvas.width, 'session.canvas.width', 1);
+  requireFrameNumber(canvas.height, 'session.canvas.height', 1);
+  requireString(canvas.canvasBackgroundColor, 'session.canvas.canvasBackgroundColor');
+  requireBoolean(canvas.showGrid, 'session.canvas.showGrid');
+
+  const timeline = requireRecord(session.timeline, 'session.timeline');
+  const frameRate = requireFiniteNumber(timeline.frameRate, 'session.timeline.frameRate');
+  if (frameRate <= 0) {
+    invalidSession('session.timeline.frameRate', 'must be greater than zero');
+  }
+  requireFrameNumber(
+    timeline.durationFrames,
+    'session.timeline.durationFrames',
+    1,
+  );
+  requireBoolean(timeline.looping, 'session.timeline.looping');
+
+  requireArray(session.layers, 'session.layers').forEach((layerValue, layerIndex) => {
+    const path = `session.layers[${layerIndex}]`;
+    const layer = requireRecord(layerValue, path);
+    requireString(layer.id, `${path}.id`);
+    requireString(layer.name, `${path}.name`);
+    requireBoolean(layer.visible, `${path}.visible`);
+    requireBoolean(layer.solo, `${path}.solo`);
+    requireBoolean(layer.locked, `${path}.locked`);
+    requireFiniteNumber(layer.opacity, `${path}.opacity`);
+    validateOptionalString(layer, 'parentGroupId', path);
+    validateOptionalBoolean(layer, 'syncKeyframesToFrames', path);
+
+    requireArray(layer.contentFrames, `${path}.contentFrames`).forEach(
+      (frameValue, frameIndex) => {
+        const framePath = `${path}.contentFrames[${frameIndex}]`;
+        const frame = requireRecord(frameValue, framePath);
+        requireString(frame.id, `${framePath}.id`);
+        requireString(frame.name, `${framePath}.name`);
+        requireFrameNumber(
+          frame.startFrame,
+          `${framePath}.startFrame`,
+          0,
+        );
+        requireFrameNumber(
+          frame.durationFrames,
+          `${framePath}.durationFrames`,
+          1,
+        );
+        validateOptionalBoolean(frame, 'hidden', framePath);
+        validateOptionalString(frame, 'labelColor', framePath);
+
+        const data = requireRecord(frame.data, `${framePath}.data`);
+        for (const [cellKey, cellValue] of Object.entries(data)) {
+          const cellPath = `${framePath}.data.${cellKey}`;
+          const cell = requireRecord(cellValue, cellPath);
+          requireString(cell.char, `${cellPath}.char`);
+          requireString(cell.color, `${cellPath}.color`);
+          requireString(cell.bgColor, `${cellPath}.bgColor`);
+        }
+      },
+    );
+
+    requireArray(layer.propertyTracks, `${path}.propertyTracks`).forEach(
+      (propertyTrack, index) => {
+        validatePropertyTrack(propertyTrack, `${path}.propertyTracks[${index}]`, false);
+      },
+    );
+    if (layer.staticProperties !== undefined) {
+      validateStaticProperties(layer.staticProperties, `${path}.staticProperties`);
+    }
+    if (layer.effectTracks !== undefined) {
+      requireArray(layer.effectTracks, `${path}.effectTracks`).forEach(
+        (effectTrack, index) => {
+          validateEffectTrack(effectTrack, `${path}.effectTracks[${index}]`);
+        },
+      );
+    }
+  });
+
+  if (session.layerGroups !== undefined) {
+    requireArray(session.layerGroups, 'session.layerGroups').forEach(
+      (groupValue, groupIndex) => {
+        const path = `session.layerGroups[${groupIndex}]`;
+        const group = requireRecord(groupValue, path);
+        requireString(group.id, `${path}.id`);
+        requireString(group.name, `${path}.name`);
+        requireArray(group.childLayerIds, `${path}.childLayerIds`).forEach(
+          (layerId, index) => requireString(layerId, `${path}.childLayerIds[${index}]`),
+        );
+        requireBoolean(group.visible, `${path}.visible`);
+        requireBoolean(group.solo, `${path}.solo`);
+        requireBoolean(group.locked, `${path}.locked`);
+        requireBoolean(group.collapsed, `${path}.collapsed`);
+        requireArray(group.propertyTracks, `${path}.propertyTracks`).forEach(
+          (propertyTrack, index) => {
+            validatePropertyTrack(propertyTrack, `${path}.propertyTracks[${index}]`, false);
+          },
+        );
+        if (group.staticProperties !== undefined) {
+          validateStaticProperties(group.staticProperties, `${path}.staticProperties`);
+        }
+        if (group.effectTracks !== undefined) {
+          requireArray(group.effectTracks, `${path}.effectTracks`).forEach(
+            (effectTrack, index) => {
+              validateEffectTrack(effectTrack, `${path}.effectTracks[${index}]`);
+            },
+          );
+        }
+      },
+    );
+  }
+
+  if (session.globalEffects !== undefined) {
+    requireArray(session.globalEffects, 'session.globalEffects').forEach(
+      (effectTrack, index) => {
+        validateEffectTrack(effectTrack, `session.globalEffects[${index}]`);
+      },
+    );
+  }
+  if (session.postEffectTracks !== undefined) {
+    requireArray(session.postEffectTracks, 'session.postEffectTracks').forEach(
+      (effectTrack, index) => {
+        validatePostEffectTrack(effectTrack, `session.postEffectTracks[${index}]`);
+      },
+    );
+  }
+
+  if (session.tools !== undefined) {
+    const tools = requireRecord(session.tools, 'session.tools');
+    if (
+      tools.activeTool !== undefined
+      && (
+        typeof tools.activeTool !== 'string'
+        || !VALID_TOOLS.has(tools.activeTool as Tool)
+      )
+    ) {
+      invalidSession('session.tools.activeTool', 'must be a supported tool');
+    }
+    validateOptionalString(tools, 'selectedColor', 'session.tools');
+    validateOptionalString(tools, 'selectedBgColor', 'session.tools');
+    validateOptionalString(tools, 'selectedCharacter', 'session.tools');
+    validateOptionalBoolean(tools, 'rectangleFilled', 'session.tools');
+  }
+
+  if (session.palettes !== undefined) {
+    const palettes = requireRecord(session.palettes, 'session.palettes');
+    validateOptionalString(palettes, 'activePaletteId', 'session.palettes');
+    if (palettes.customPalettes !== undefined) {
+      const customPalettes = requireArray(
+        palettes.customPalettes,
+        'session.palettes.customPalettes',
+      );
+      if (!customPalettes.every(isColorPalette)) {
+        invalidSession(
+          'session.palettes.customPalettes',
+          'must contain valid color palettes',
+        );
+      }
+    }
+    if (palettes.recentColors !== undefined) {
+      requireArray(palettes.recentColors, 'session.palettes.recentColors').forEach(
+        (color, index) => requireString(color, `session.palettes.recentColors[${index}]`),
+      );
+    }
+  }
+
+  if (session.characterPalettes !== undefined) {
+    const palettes = requireRecord(
+      session.characterPalettes,
+      'session.characterPalettes',
+    );
+    validateOptionalString(
+      palettes,
+      'activePaletteId',
+      'session.characterPalettes',
+    );
+    if (palettes.customPalettes !== undefined) {
+      const customPalettes = requireArray(
+        palettes.customPalettes,
+        'session.characterPalettes.customPalettes',
+      );
+      if (!customPalettes.every(isCharacterPalette)) {
+        invalidSession(
+          'session.characterPalettes.customPalettes',
+          'must contain valid character palettes',
+        );
+      }
+    }
+    if (palettes.mappingMethod !== undefined) {
+      if (
+        typeof palettes.mappingMethod !== 'string'
+        || !VALID_MAPPING_METHODS.has(
+          palettes.mappingMethod as CharacterMappingSettings['mappingMethod'],
+        )
+      ) {
+        invalidSession(
+          'session.characterPalettes.mappingMethod',
+          'must be a supported mapping method',
+        );
+      }
+    }
+    validateOptionalBoolean(
+      palettes,
+      'invertDensity',
+      'session.characterPalettes',
+    );
+    if (palettes.characterSpacing !== undefined) {
+      requireFiniteNumber(
+        palettes.characterSpacing,
+        'session.characterPalettes.characterSpacing',
+      );
+    }
+  }
+
+  if (session.typography !== undefined) {
+    const typography = requireRecord(session.typography, 'session.typography');
+    for (const property of ['fontSize', 'characterSpacing', 'lineSpacing']) {
+      if (typography[property] !== undefined) {
+        requireFiniteNumber(typography[property], `session.typography.${property}`);
+      }
+    }
+    validateOptionalString(typography, 'selectedFontId', 'session.typography');
+  }
+}
+
 /**
  * Session Import Utility
  * Handles loading and restoring session data from .asciimtn files
@@ -431,6 +867,8 @@ export class SessionImporter {
     sessionData: SessionDataV2,
     typographyCallbacks?: TypographyCallbacks,
   ): Promise<void> {
+    validateSessionDataV2ForImport(sessionData);
+
     const animationStore = useAnimationStore.getState();
     animationStore.setImportingSession(true);
 

--- a/src/utils/sessionImporter.ts
+++ b/src/utils/sessionImporter.ts
@@ -13,6 +13,7 @@ import type { TypographySettings } from './canvasSizeConversion';
 import type { ColorPalette, CharacterPalette, CharacterMappingSettings } from '../types/palette';
 import { isColorPalette, isCharacterPalette } from '../types/palette';
 import { detectSessionVersion, migrateV1ToV2, validateAndRepairV2 } from './sessionMigration';
+import { getContentFrameAtTime } from './layerCompositing';
 
 type SessionFrameCells = Record<string, Cell>;
 
@@ -72,6 +73,18 @@ interface SessionImportData {
   characterPalettes?: SessionCharacterPalettesData;
 }
 
+interface TypographyCallbacks {
+  setFontSize: (size: number) => void;
+  setCharacterSpacing: (spacing: number) => void;
+  setLineSpacing: (spacing: number) => void;
+  setSelectedFontId?: (fontId: string) => void;
+}
+
+interface InstalledSessionCanvas {
+  activeLayerId: LayerId | null;
+  cells: Map<string, Cell>;
+}
+
 /**
  * Session Import Utility
  * Handles loading and restoring session data from .asciimtn files
@@ -82,69 +95,71 @@ export class SessionImporter {
    * Import session data from a JSON file
    */
   static async importSessionFile(
-    file: File, 
-    typographyCallbacks?: {
-      setFontSize: (size: number) => void;
-      setCharacterSpacing: (spacing: number) => void;
-      setLineSpacing: (spacing: number) => void;
-      setSelectedFontId?: (fontId: string) => void;
-    }
+    file: File,
+    typographyCallbacks?: TypographyCallbacks,
   ): Promise<void> {
-    return new Promise((resolve, reject) => {
+    const content = await new Promise<string>((resolve, reject) => {
       const reader = new FileReader();
-      
+
       reader.onload = (event) => {
-        try {
-          const content = event.target?.result as string;
-          const rawData = JSON.parse(content) as unknown;
-          
-          // Detect session format version
-          const version = detectSessionVersion(rawData);
-          
-          if (version === '2.0.0') {
-            // V2: Validate, repair, and load layer data directly
-            const { data: repairedData, repairs } = validateAndRepairV2(rawData as SessionDataV2);
-            if (repairs.length > 0) {
-              console.warn(`Session import: ${repairs.length} repairs applied:`, repairs);
-            }
-            SessionImporter.restoreSessionDataV2(repairedData, typographyCallbacks);
-          } else if (version === '1.0.0') {
-            // V1: Migrate to v2 format and load into timeline
-            // All projects are forced into timeline mode (no legacy frame path)
-            console.log('Migrating v1 session to v2 timeline format...');
-            const migrated = migrateV1ToV2(rawData);
-            const { data: repairedData, repairs } = validateAndRepairV2(migrated);
-            if (repairs.length > 0) {
-              console.warn(`Session v1→v2 migration: ${repairs.length} repairs applied:`, repairs);
-            }
-            SessionImporter.restoreSessionDataV2(repairedData, typographyCallbacks);
-          } else {
-            // Unknown: Attempt v1→v2 migration as fallback
-            try {
-              const migrated = migrateV1ToV2(rawData);
-              const { data: repairedData, repairs } = validateAndRepairV2(migrated);
-              if (repairs.length > 0) {
-                console.warn(`Session migration: ${repairs.length} repairs applied:`, repairs);
-              }
-              SessionImporter.restoreSessionDataV2(repairedData, typographyCallbacks);
-              console.log('Session imported via v1→v2 migration fallback');
-            } catch {
-              throw new Error('Unknown session file format');
-            }
-          }
-          
-          resolve();
-        } catch (error) {
-          reject(new Error(`Failed to import session: ${error instanceof Error ? error.message : 'Unknown error'}`));
+        if (typeof event.target?.result !== 'string') {
+          reject(new Error('Failed to read file'));
+          return;
         }
+
+        resolve(event.target.result);
       };
-      
+
       reader.onerror = () => {
         reject(new Error('Failed to read file'));
       };
-      
+
       reader.readAsText(file);
     });
+
+    let rawData: unknown;
+    try {
+      rawData = JSON.parse(content) as unknown;
+    } catch (error) {
+      throw new Error(`Failed to import session: ${error instanceof Error ? error.message : 'Invalid JSON'}`);
+    }
+
+    await SessionImporter.importSessionData(rawData, typographyCallbacks);
+  }
+
+  /**
+   * Import already-parsed session data and resolve only after every store,
+   * including the active canvas, reflects the loaded project.
+   */
+  static async importSessionData(
+    rawData: unknown,
+    typographyCallbacks?: TypographyCallbacks,
+  ): Promise<void> {
+    try {
+      const version = detectSessionVersion(rawData);
+      let sessionData: SessionDataV2;
+
+      if (version === '2.0.0') {
+        const { data, repairs } = validateAndRepairV2(rawData as SessionDataV2);
+        if (repairs.length > 0) {
+          console.warn(`Session import: ${repairs.length} repairs applied:`, repairs);
+        }
+        sessionData = data;
+      } else if (version === '1.0.0') {
+        const migrated = migrateV1ToV2(rawData);
+        const { data, repairs } = validateAndRepairV2(migrated);
+        if (repairs.length > 0) {
+          console.warn(`Session v1->v2 migration: ${repairs.length} repairs applied:`, repairs);
+        }
+        sessionData = data;
+      } else {
+        throw new Error('Unknown session file format');
+      }
+
+      await SessionImporter.restoreSessionDataV2(sessionData, typographyCallbacks);
+    } catch (error) {
+      throw new Error(`Failed to import session: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
   }
   
   /**
@@ -412,15 +427,39 @@ export class SessionImporter {
    * Loads layers into timelineStore, canvas settings into canvasStore,
    * and tool/palette/typography state into their respective stores.
    */
-  private static restoreSessionDataV2(
+  private static async restoreSessionDataV2(
     sessionData: SessionDataV2,
-    typographyCallbacks?: {
-      setFontSize: (size: number) => void;
-      setCharacterSpacing: (spacing: number) => void;
-      setLineSpacing: (spacing: number) => void;
-      setSelectedFontId?: (fontId: string) => void;
+    typographyCallbacks?: TypographyCallbacks,
+  ): Promise<void> {
+    const animationStore = useAnimationStore.getState();
+    animationStore.setImportingSession(true);
+
+    try {
+      const installedCanvas = SessionImporter.installSessionDataV2(
+        sessionData,
+        typographyCallbacks,
+      );
+
+      // Preserve the import guard across a render boundary. This lets
+      // useFrameSynchronization observe the temporary null active layer and
+      // prevents it from flushing a pre-import layer into loaded data when IDs
+      // collide during a round-trip import.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      useTimelineStore.getState().setActiveLayer(installedCanvas.activeLayerId);
+      const canvasStore = useCanvasStore.getState();
+      canvasStore.setActiveLayerId(installedCanvas.activeLayerId);
+      canvasStore.setCanvasData(installedCanvas.cells);
+      canvasStore.setDirty(false);
+    } finally {
+      animationStore.setImportingSession(false);
     }
-  ): void {
+  }
+
+  private static installSessionDataV2(
+    sessionData: SessionDataV2,
+    typographyCallbacks?: TypographyCallbacks,
+  ): InstalledSessionCanvas {
     const canvasStore = useCanvasStore.getState();
     const toolStore = useToolStore.getState();
     const paletteStore = usePaletteStore.getState();
@@ -449,7 +488,6 @@ export class SessionImporter {
     // Guard: block auto-save during session import to prevent race conditions.
     // Must be set BEFORE clearCanvas() to prevent the auto-save subscription from
     // scheduling saves during the import window.
-    animationStore.setImportingSession(true);
     canvasStore.clearCanvas();
 
     // Deserialize layers: convert Record<string, Cell> back to Map<string, Cell>
@@ -622,20 +660,6 @@ export class SessionImporter {
       postEffectTracksData,
     );
 
-    // Force activeLayerId change: null → layers[0].id
-    // This guarantees the layer-switch useEffect in useFrameSynchronization
-    // fires on EVERY load (first or repeat) because the layer ID always changes.
-    // The effect will load the active layer's content frame into canvasStore.
-    const activeId = layers.length > 0 ? layers[0].id : null;
-    timelineStore.setActiveLayer(null as unknown as LayerId);
-    // Defer the real activation so React sees the null → id transition
-    setTimeout(() => {
-      if (activeId) {
-        timelineStore.setActiveLayer(activeId);
-      }
-      animationStore.setImportingSession(false);
-    }, 0);
-
     // Restore tool state
     const tools = sessionData.tools as Record<string, unknown> | undefined;
     if (tools) {
@@ -703,6 +727,27 @@ export class SessionImporter {
         typographyCallbacks.setSelectedFontId(fontId);
       }
     }
+
+    animationStore.setCurrentFrame(0);
+
+    const restoredTimeline = useTimelineStore.getState();
+    const activeLayer = restoredTimeline.layers.find(
+      (layer) => layer.id === restoredTimeline.view.activeLayerId,
+    ) ?? restoredTimeline.layers[0];
+    const activeFrame = activeLayer
+      ? getContentFrameAtTime(activeLayer, restoredTimeline.view.currentFrame)
+      : null;
+    const installedCanvas: InstalledSessionCanvas = {
+      activeLayerId: activeLayer?.id ?? null,
+      cells: activeFrame ? new Map(activeFrame.data) : new Map<string, Cell>(),
+    };
+
+    timelineStore.setActiveLayer(null);
+    canvasStore.setActiveLayerId(null);
+    canvasStore.setCanvasData(installedCanvas.cells);
+    canvasStore.setDirty(false);
+
+    return installedCanvas;
   }
 }
 
@@ -711,13 +756,8 @@ export class SessionImporter {
  */
 export const useSessionImporter = () => {
   const importSession = async (
-    file: File, 
-    typographyCallbacks?: {
-      setFontSize: (size: number) => void;
-      setCharacterSpacing: (spacing: number) => void;
-      setLineSpacing: (spacing: number) => void;
-      setSelectedFontId?: (fontId: string) => void;
-    }
+    file: File,
+    typographyCallbacks?: TypographyCallbacks,
   ): Promise<void> => {
     try {
       await SessionImporter.importSessionFile(file, typographyCallbacks);


### PR DESCRIPTION
## Summary

Adds the Ascii-Motion browser companion for #153 and the shared targeted cell-batch support needed by #152.

- serializes authoritative browser commands FIFO and emits exactly one correlated success or failure result
- applies `set_cells_batch` to an exact active-layer content-frame entry, including inactive entries, while keeping `canvasStore` synchronized for the installed frame
- applies FPS changes with `timelineStore.setFrameRate(fps, false)` and reflows legacy frame-duration sequences
- exposes awaitable raw-data session import for v1/v2 migration, validation, store restoration, and final active-canvas installation
- preserves legacy command and JSON-RPC notification inputs

## Wire contract

Server to browser:

```ts
interface MCPCommandRequest {
  type: 'command_request';
  requestId: string;
  command: MCPCommand;
}
```

Browser to server:

```ts
type MCPCommandResult =
  | {
      type: 'command_result';
      requestId: string;
      success: true;
      applied?: {
        currentFrameIndex?: number;
        cellsChanged?: number;
        frameRate?: number;
        durationMs?: number;
      };
    }
  | {
      type: 'command_result';
      requestId: string;
      success: false;
      error: string;
    };
```

Acknowledged requests execute and emit results strictly FIFO, including async handlers. Supported command payloads added here are:

```ts
{ type: 'set_cells_batch'; cells: Array<{ x: number; y: number; cell: Cell }>; frameIndex?: number }
{ type: 'set_frame_rate'; fps: number }
{ type: 'set_frame_duration'; index: number; duration: number } // duration is milliseconds
{ type: 'load_project'; sessionData: unknown }
```

## Dependency

This is the browser half of the cross-repository #153 fix. It can merge independently, but acknowledged live mutations require the pending `CameronFoxly/ascii-motion-mcp` #153 companion PR to emit `command_request` and await `command_result` using the exact contract above. The targeted `set_cells_batch.frameIndex` behavior is also the shared browser primitive for the ascii-motion-mcp #152 image-import companion; no import-specific browser command is introduced.

The navigation-specific atomic completion required by #154 is intentionally excluded and will be added in a stacked browser companion using this dispatcher's async `executeCommand` extension point.

Refs #153
Refs #152

## Validation

- `npm test -- --run src/__tests__/mcpClient.test.ts src/__tests__/sessionMigration.test.ts src/__tests__/phase6Integration.test.ts` (58 tests)
- `npm run build`
- targeted ESLint on changed files