### PR TITLE
Make acknowledged MCP frame navigation atomic

### DIFF
--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -1,4 +1,6 @@
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFrameSynchronization } from '../hooks/useFrameSynchronization';
 import { MCPClient } from '../mcp/client';
 import { MCPCommandDispatcher } from '../mcp/commandDispatcher';
 import { useMCPStore } from '../mcp/store';
@@ -399,6 +401,197 @@ describe('MCPClient acknowledged commands', () => {
       (entry) => entry.requestId === 'invalid-batch',
     )).toHaveLength(1);
     expect(useCanvasStore.getState().cells.size).toBe(0);
+  });
+
+  it('installs navigation before acknowledging and serializes an immediate current-frame batch', async () => {
+    const timeline = useTimelineStore.getState();
+    const layer = timeline.layers[0];
+    timeline.updateContentFrameData(layer.id, layer.contentFrames[0].id, new Map([
+      ['0,0', cell('stored-old')],
+    ]));
+    timeline.addContentFrame(layer.id, 1, 1, new Map([
+      ['0,0', cell('target')],
+    ]));
+    timeline.setDuration(2);
+    timeline.goToFrame(0);
+    useCanvasStore.setState({
+      cells: new Map([['0,0', cell('canvas-old')]]),
+      activeLayerId: layer.id,
+      isDirty: true,
+    });
+
+    const { unmount } = renderHook(() => useFrameSynchronization());
+    const socket = await connected();
+    const resultCanvasSnapshots = new Map<string, Map<string, Cell>>();
+    vi.spyOn(socket, 'send').mockImplementation((data) => {
+      socket.sent.push(data);
+      const message = JSON.parse(data) as Partial<MCPCommandResult>;
+      if (message.type === 'command_result' && message.requestId) {
+        resultCanvasSnapshots.set(
+          message.requestId,
+          new Map(useCanvasStore.getState().cells),
+        );
+      }
+    });
+
+    act(() => {
+      socket.receive({
+        type: 'command_request',
+        requestId: 'navigate',
+        command: { type: 'go_to_frame', index: 1 },
+      });
+      socket.receive({
+        type: 'command_request',
+        requestId: 'mutate-target',
+        command: {
+          type: 'set_cells_batch',
+          cells: [{ x: 1, y: 0, cell: cell('pasted') }],
+        },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(sentCommandResults(socket)).toHaveLength(2);
+    });
+
+    const results = sentCommandResults(socket);
+    expect(results.map((result) => result.requestId)).toEqual([
+      'navigate',
+      'mutate-target',
+    ]);
+    expect(results[0]).toEqual({
+      type: 'command_result',
+      requestId: 'navigate',
+      success: true,
+      applied: { currentFrameIndex: 1 },
+    });
+    expect(resultCanvasSnapshots.get('navigate')).toEqual(new Map([
+      ['0,0', cell('target')],
+    ]));
+    expect(resultCanvasSnapshots.get('mutate-target')).toEqual(new Map([
+      ['0,0', cell('target')],
+      ['1,0', cell('pasted')],
+    ]));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+
+    const appliedLayer = useTimelineStore.getState().layers[0];
+    expect(appliedLayer.contentFrames[0].data).toEqual(new Map([
+      ['0,0', cell('canvas-old')],
+    ]));
+    expect(appliedLayer.contentFrames[1].data).toEqual(new Map([
+      ['0,0', cell('target')],
+      ['1,0', cell('pasted')],
+    ]));
+    expect(useCanvasStore.getState().cells).toEqual(appliedLayer.contentFrames[1].data);
+    unmount();
+  });
+
+  it('preserves the first immediate mutation after navigating to an empty target frame', async () => {
+    const timeline = useTimelineStore.getState();
+    const layer = timeline.layers[0];
+    timeline.updateContentFrameData(layer.id, layer.contentFrames[0].id, new Map([
+      ['0,0', cell('stored-old')],
+    ]));
+    timeline.addContentFrame(layer.id, 1, 1, new Map());
+    timeline.setDuration(2);
+    timeline.goToFrame(0);
+    useCanvasStore.setState({
+      cells: new Map([['0,0', cell('canvas-old')]]),
+      activeLayerId: layer.id,
+      isDirty: true,
+    });
+
+    const { unmount } = renderHook(() => useFrameSynchronization());
+    const socket = await connected();
+
+    act(() => {
+      socket.receive({
+        type: 'command_request',
+        requestId: 'navigate-empty',
+        command: { type: 'go_to_frame', index: 1 },
+      });
+      socket.receive({
+        type: 'command_request',
+        requestId: 'mutate-empty',
+        command: {
+          type: 'set_cells_batch',
+          cells: [{ x: 1, y: 0, cell: cell('first') }],
+        },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(sentCommandResults(socket)).toHaveLength(2);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+
+    expect(sentCommandResults(socket).map((result) => result.requestId)).toEqual([
+      'navigate-empty',
+      'mutate-empty',
+    ]);
+    const appliedLayer = useTimelineStore.getState().layers[0];
+    expect(appliedLayer.contentFrames[0].data).toEqual(new Map([
+      ['0,0', cell('canvas-old')],
+    ]));
+    expect(appliedLayer.contentFrames[1].data).toEqual(new Map([
+      ['1,0', cell('first')],
+    ]));
+    expect(useCanvasStore.getState().cells).toEqual(appliedLayer.contentFrames[1].data);
+    unmount();
+  });
+
+  it('returns a correlated failure when atomic frame synchronization is unavailable', async () => {
+    const timeline = useTimelineStore.getState();
+    timeline.setDuration(2);
+    const socket = await connected();
+
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'navigation-unavailable',
+      command: { type: 'go_to_frame', index: 1 },
+    });
+
+    expect(result).toEqual({
+      type: 'command_result',
+      requestId: 'navigation-unavailable',
+      success: false,
+      error: 'Frame synchronization is unavailable',
+    });
+    expect(useTimelineStore.getState().view.currentFrame).toBe(0);
+  });
+
+  it('rejects an out-of-range navigation without changing installed state', async () => {
+    const timeline = useTimelineStore.getState();
+    timeline.setDuration(2);
+    const beforeCanvas = new Map([['0,0', cell('current')]]);
+    useCanvasStore.setState({
+      cells: beforeCanvas,
+      activeLayerId: timeline.layers[0].id,
+      isDirty: true,
+    });
+    const { unmount } = renderHook(() => useFrameSynchronization());
+    const socket = await connected();
+
+    const result = await sendCommand(socket, {
+      type: 'command_request',
+      requestId: 'invalid-navigation',
+      command: { type: 'go_to_frame', index: 2 },
+    });
+
+    expect(result).toEqual({
+      type: 'command_result',
+      requestId: 'invalid-navigation',
+      success: false,
+      error: 'go_to_frame index 2 is out of range for 2 timeline frames',
+    });
+    expect(useTimelineStore.getState().view.currentFrame).toBe(0);
+    expect(useCanvasStore.getState().cells).toEqual(beforeCanvas);
+    unmount();
   });
 
   it('changes playback speed while preserving frame counts and timings', async () => {

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -403,16 +403,22 @@ describe('MCPClient acknowledged commands', () => {
     expect(useCanvasStore.getState().cells.size).toBe(0);
   });
 
-  it('installs navigation before acknowledging and serializes an immediate current-frame batch', async () => {
+  it('serializes variable-duration navigation before an immediate current-frame batch', async () => {
     const timeline = useTimelineStore.getState();
     const layer = timeline.layers[0];
     timeline.updateContentFrameData(layer.id, layer.contentFrames[0].id, new Map([
       ['0,0', cell('stored-old')],
     ]));
-    timeline.addContentFrame(layer.id, 1, 1, new Map([
+    timeline.setDuration(6);
+    expect(timeline.updateContentFrameTiming(
+      layer.id,
+      layer.contentFrames[0].id,
+      0,
+      5,
+    )).toBe(true);
+    timeline.addContentFrame(layer.id, 5, 1, new Map([
       ['0,0', cell('target')],
     ]));
-    timeline.setDuration(2);
     timeline.goToFrame(0);
     useCanvasStore.setState({
       cells: new Map([['0,0', cell('canvas-old')]]),
@@ -438,7 +444,7 @@ describe('MCPClient acknowledged commands', () => {
       socket.receive({
         type: 'command_request',
         requestId: 'navigate',
-        command: { type: 'go_to_frame', index: 1 },
+        command: { type: 'go_to_frame', index: 5 },
       });
       socket.receive({
         type: 'command_request',
@@ -463,7 +469,13 @@ describe('MCPClient acknowledged commands', () => {
       type: 'command_result',
       requestId: 'navigate',
       success: true,
-      applied: { currentFrameIndex: 1 },
+      applied: { currentFrameIndex: 5 },
+    });
+    expect(results[1]).toEqual({
+      type: 'command_result',
+      requestId: 'mutate-target',
+      success: true,
+      applied: { currentFrameIndex: 5, cellsChanged: 1 },
     });
     expect(resultCanvasSnapshots.get('navigate')).toEqual(new Map([
       ['0,0', cell('target')],
@@ -478,6 +490,7 @@ describe('MCPClient acknowledged commands', () => {
     });
 
     const appliedLayer = useTimelineStore.getState().layers[0];
+    expect(useTimelineStore.getState().view.currentFrame).toBe(5);
     expect(appliedLayer.contentFrames[0].data).toEqual(new Map([
       ['0,0', cell('canvas-old')],
     ]));

--- a/src/__tests__/mcpFrameNavigation.test.ts
+++ b/src/__tests__/mcpFrameNavigation.test.ts
@@ -1,0 +1,198 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFrameSynchronization } from '../hooks/useFrameSynchronization';
+import { navigateToFrameAtomically } from '../mcp/frameNavigation';
+import { useAnimationStore } from '../stores/animationStore';
+import { useCanvasStore } from '../stores/canvasStore';
+import { useTimelineStore } from '../stores/timelineStore';
+import type { Cell } from '../types';
+
+function cell(char: string): Cell {
+  return {
+    char,
+    color: '#ffffff',
+    bgColor: '#000000',
+  };
+}
+
+function resetStores(): void {
+  useTimelineStore.getState().createNewProject();
+  useCanvasStore.setState({
+    width: 80,
+    height: 24,
+    cells: new Map(),
+    canvasBackgroundColor: '#000000',
+    showGrid: true,
+    activeLayerId: null,
+    isDirty: false,
+  });
+  useAnimationStore.setState({
+    isImportingSession: false,
+    selectedFrameIndices: new Set([0]),
+  });
+}
+
+function setUpTwoFrames(targetData: Map<string, Cell>): void {
+  const timeline = useTimelineStore.getState();
+  const layer = timeline.layers[0];
+  timeline.updateContentFrameData(
+    layer.id,
+    layer.contentFrames[0].id,
+    new Map([['0,0', cell('stored-old')]]),
+  );
+  timeline.addContentFrame(layer.id, 1, 1, targetData);
+  timeline.setDuration(2);
+  timeline.goToFrame(0);
+
+  useCanvasStore.setState({
+    cells: new Map([['0,0', cell('canvas-old')]]),
+    activeLayerId: layer.id,
+    isDirty: true,
+  });
+}
+
+describe('atomic MCP frame navigation', () => {
+  beforeEach(resetStores);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('flushes the old canvas, sets the playhead, and loads populated target data before resolving', async () => {
+    setUpTwoFrames(new Map([['1,0', cell('target')]]));
+    const timelineEvents: string[] = [];
+    let previousCanvasCells = useCanvasStore.getState().cells;
+
+    const unsubscribeTimeline = useTimelineStore.subscribe((state) => {
+      if (state.view.currentFrame !== 1) return;
+      expect(state.layers[0].contentFrames[0].data.get('0,0')).toEqual(cell('canvas-old'));
+      timelineEvents.push('playhead');
+    });
+    const unsubscribeCanvas = useCanvasStore.subscribe((state) => {
+      if (state.cells === previousCanvasCells) return;
+      previousCanvasCells = state.cells;
+      expect(useTimelineStore.getState().view.currentFrame).toBe(1);
+      timelineEvents.push('canvas');
+    });
+    const { unmount } = renderHook(() => useFrameSynchronization());
+
+    let applied = -1;
+    await act(async () => {
+      applied = await navigateToFrameAtomically(1);
+    });
+
+    expect(applied).toBe(1);
+    expect(timelineEvents.slice(0, 2)).toEqual(['playhead', 'canvas']);
+    expect(useTimelineStore.getState().layers[0].contentFrames[0].data.get('0,0')).toEqual(
+      cell('canvas-old'),
+    );
+    expect(useCanvasStore.getState().cells).toEqual(new Map([['1,0', cell('target')]]));
+    expect(useCanvasStore.getState().cells).not.toBe(
+      useTimelineStore.getState().layers[0].contentFrames[1].data,
+    );
+
+    unsubscribeTimeline();
+    unsubscribeCanvas();
+    unmount();
+  });
+
+  it('installs an empty canvas for an empty target frame', async () => {
+    setUpTwoFrames(new Map());
+    const { unmount } = renderHook(() => useFrameSynchronization());
+
+    await act(async () => {
+      await navigateToFrameAtomically(1);
+    });
+
+    expect(useTimelineStore.getState().view.currentFrame).toBe(1);
+    expect(useTimelineStore.getState().layers[0].contentFrames[0].data.get('0,0')).toEqual(
+      cell('canvas-old'),
+    );
+    expect(useCanvasStore.getState().cells.size).toBe(0);
+    unmount();
+  });
+
+  it('flushes the layer installed on canvas when a timeline layer switch is still pending', async () => {
+    setUpTwoFrames(new Map([['1,0', cell('layer-one-target')]]));
+    const timeline = useTimelineStore.getState();
+    const firstLayer = timeline.layers[0];
+    const secondLayerId = timeline.addLayer('Layer 2');
+    if (!secondLayerId) {
+      throw new Error('Failed to add second layer');
+    }
+    timeline.updateContentFrameData(
+      secondLayerId,
+      useTimelineStore.getState().getLayer(secondLayerId)!.contentFrames[0].id,
+      new Map([['2,0', cell('layer-two')]]),
+    );
+    timeline.setActiveLayer(firstLayer.id);
+    useCanvasStore.setState({
+      cells: new Map([['0,0', cell('unsaved-layer-one')]]),
+      activeLayerId: firstLayer.id,
+      isDirty: true,
+    });
+    const { unmount } = renderHook(() => useFrameSynchronization());
+
+    useTimelineStore.getState().setActiveLayer(secondLayerId);
+    await navigateToFrameAtomically(0);
+
+    expect(
+      useTimelineStore.getState().getLayer(firstLayer.id)!.contentFrames[0].data.get('0,0'),
+    ).toEqual(cell('unsaved-layer-one'));
+    expect(
+      useTimelineStore.getState().getLayer(secondLayerId)!.contentFrames[0].data,
+    ).toEqual(new Map([['2,0', cell('layer-two')]]));
+    expect(useCanvasStore.getState().cells).toEqual(new Map([['2,0', cell('layer-two')]]));
+    expect(useCanvasStore.getState().activeLayerId).toBe(secondLayerId);
+    unmount();
+  });
+
+  it.each([-1, 2, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid index %s without changing frame or canvas state',
+    async (index) => {
+      setUpTwoFrames(new Map([['1,0', cell('target')]]));
+      const beforeTimelineData = new Map(
+        useTimelineStore.getState().layers[0].contentFrames[0].data,
+      );
+      const beforeCanvasData = new Map(useCanvasStore.getState().cells);
+      const { unmount } = renderHook(() => useFrameSynchronization());
+
+      await expect(navigateToFrameAtomically(index)).rejects.toThrow(/go_to_frame index/);
+
+      expect(useTimelineStore.getState().view.currentFrame).toBe(0);
+      expect(useTimelineStore.getState().layers[0].contentFrames[0].data).toEqual(
+        beforeTimelineData,
+      );
+      expect(useCanvasStore.getState().cells).toEqual(beforeCanvasData);
+      unmount();
+    },
+  );
+
+  it('propagates a transition failure and releases the loading guard', async () => {
+    setUpTwoFrames(new Map([['1,0', cell('target')]]));
+    let shouldThrow = true;
+    const moveState = {
+      originalData: new Map<string, Cell>(),
+      originalPositions: new Set<string>(),
+      startPos: { x: 0, y: 0 },
+      baseOffset: { x: 0, y: 0 },
+      currentOffset: { x: 0, y: 0 },
+    };
+    const setMoveState = (() => {
+      if (shouldThrow) {
+        throw new Error('move commit failed');
+      }
+    }) as NonNullable<Parameters<typeof useFrameSynchronization>[1]>;
+    const { unmount } = renderHook(() => useFrameSynchronization(moveState, setMoveState));
+
+    await expect(navigateToFrameAtomically(1)).rejects.toThrow('move commit failed');
+    shouldThrow = false;
+
+    await act(async () => {
+      await expect(navigateToFrameAtomically(1)).resolves.toBe(1);
+    });
+
+    expect(useCanvasStore.getState().cells.get('1,0')).toEqual(cell('target'));
+    unmount();
+  });
+});

--- a/src/hooks/useFrameSynchronization.ts
+++ b/src/hooks/useFrameSynchronization.ts
@@ -6,6 +6,7 @@ import { useToolStore } from '../stores/toolStore';
 import { useSelectionStore } from '../stores/selectionStore';
 import { getContentFrameAtTime } from '../utils/layerCompositing';
 import type { Cell } from '../types';
+import { registerAtomicFrameNavigator } from '../mcp/frameNavigation';
 
 /**
  * Hook that manages synchronization between canvas state and animation frames.
@@ -95,12 +96,25 @@ export const useFrameSynchronization = (
   const isLoadingFrameRef = useRef<boolean>(false);
   const frameWasEmptyOnLoadRef = useRef<boolean>(false);
   const lastActiveLayerIdRef = useRef<string | null>(activeLayerId);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Keep refs in sync for use in non-reactive callbacks
   const effectiveFrameIndexRef = useRef(effectiveFrameIndex);
   effectiveFrameIndexRef.current = effectiveFrameIndex;
   const setFrameDataRef = useRef(setFrameData);
   setFrameDataRef.current = setFrameData;
+
+  const installFrameData = useCallback((frameData?: Map<string, Cell>) => {
+    const nextCells = frameData && frameData.size > 0
+      ? new Map(frameData)
+      : new Map<string, Cell>();
+    setCanvasData(nextCells);
+
+    const installedCells = useCanvasStore.getState().cells;
+    cellsRef.current = installedCells;
+    lastCellsRef.current = installedCells;
+    frameWasEmptyOnLoadRef.current = installedCells.size === 0;
+  }, [setCanvasData]);
 
   // ── Layer-switch sync ──
   // When the active layer changes, flush canvas to the old layer's content frame
@@ -132,21 +146,85 @@ export const useFrameSynchronization = (
     const newLayer = tl.layers.find((l) => l.id === activeLayerId);
     if (newLayer) {
       const newCf = getContentFrameAtTime(newLayer, frame);
-      if (newCf && newCf.data.size > 0) {
-        setCanvasData(new Map(newCf.data));
-        lastCellsRef.current = new Map(newCf.data);
-      } else {
-        setCanvasData(new Map());
-        lastCellsRef.current = new Map();
-      }
+      installFrameData(newCf?.data);
+      useCanvasStore.getState().setActiveLayerId(newLayer.id);
     } else {
-      setCanvasData(new Map());
-      lastCellsRef.current = new Map();
+      installFrameData();
+      useCanvasStore.getState().setActiveLayerId(null);
     }
+    useCanvasStore.getState().setDirty(false);
     setTimeout(() => { isLoadingFrameRef.current = false; }, 0);
 
     lastActiveLayerIdRef.current = activeLayerId;
-  }, [activeLayerId, isLayerMode, isPlaying, isImportingSession, setCanvasData]);
+  }, [activeLayerId, isLayerMode, isPlaying, isImportingSession, installFrameData]);
+
+  const commitPendingMove = useCallback((fallbackCells: Map<string, Cell>): Map<string, Cell> => {
+    if (!moveStateParam || !setMoveStateParam) {
+      return fallbackCells;
+    }
+
+    const totalOffset = {
+      x: moveStateParam.baseOffset.x + moveStateParam.currentOffset.x,
+      y: moveStateParam.baseOffset.y + moveStateParam.currentOffset.y
+    };
+    const newCells = new Map(cellsRef.current);
+    const originalKeys = moveStateParam.originalPositions ?? new Set(moveStateParam.originalData.keys());
+    originalKeys.forEach((key) => {
+      newCells.delete(key);
+    });
+
+    const updatedSelectionMask = new Set<string>();
+    moveStateParam.originalData.forEach((cell, key) => {
+      const [origX, origY] = key.split(',').map(Number);
+      const newX = origX + totalOffset.x;
+      const newY = origY + totalOffset.y;
+
+      if (newX >= 0 && newX < widthRef.current && newY >= 0 && newY < heightRef.current) {
+        newCells.set(`${newX},${newY}`, cell);
+        updatedSelectionMask.add(`${newX},${newY}`);
+      }
+    });
+
+    const toolStore = useToolStore.getState();
+    const activeSelection = toolStore.selection.active ? toolStore.selection.selectedCells
+      : (toolStore.lassoSelection.active ? toolStore.lassoSelection.selectedCells
+      : (toolStore.magicWandSelection.active ? toolStore.magicWandSelection.selectedCells : null));
+
+    if (activeSelection) {
+      activeSelection.forEach((key) => {
+        const [origX, origY] = key.split(',').map(Number);
+        const newX = origX + totalOffset.x;
+        const newY = origY + totalOffset.y;
+        if (newX >= 0 && newX < widthRef.current && newY >= 0 && newY < heightRef.current) {
+          updatedSelectionMask.add(`${newX},${newY}`);
+        }
+      });
+    }
+
+    setCanvasData(newCells);
+
+    if (updatedSelectionMask.size > 0) {
+      const { activeTool } = toolStore;
+      toolStore.clearSelection();
+      toolStore.clearLassoSelection();
+      toolStore.clearMagicWandSelection();
+
+      if (activeTool === 'select') {
+        toolStore.setSelectionFromMask(updatedSelectionMask);
+      } else if (activeTool === 'lasso') {
+        toolStore.setLassoSelectionFromMask(updatedSelectionMask, []);
+      } else if (activeTool === 'magicwand') {
+        toolStore.setMagicWandSelectionFromMask(updatedSelectionMask);
+      } else {
+        toolStore.setSelectionFromMask(updatedSelectionMask);
+      }
+
+      useSelectionStore.getState().setSelection(updatedSelectionMask);
+    }
+
+    setMoveStateParam(null);
+    return newCells;
+  }, [moveStateParam, setMoveStateParam, setCanvasData]);
 
   // Auto-save current canvas to current frame whenever canvas changes
   const saveCurrentCanvasToFrame = useCallback(() => {
@@ -160,121 +238,98 @@ export const useFrameSynchronization = (
   // Load frame data into canvas when frame changes
   const loadFrameToCanvas = useCallback((frameIndex: number) => {
     isLoadingFrameRef.current = true;
-    
-    const frameData = getFrameData(frameIndex);
-    
-    if (frameData && frameData.size > 0) {
-      setCanvasData(frameData);
-      // Update the reference to prevent false auto-save triggers
-      lastCellsRef.current = new Map(frameData);
-      frameWasEmptyOnLoadRef.current = false;
-    } else {
-      // If frame has no data, clear canvas
-      setCanvasData(new Map());
-      // Update the reference to reflect the empty canvas
-      lastCellsRef.current = new Map();
-      frameWasEmptyOnLoadRef.current = true;
-    }
+    installFrameData(getFrameData(frameIndex));
     
     // Small delay to ensure canvas update completes
     setTimeout(() => {
       isLoadingFrameRef.current = false;
     }, 0);
-  }, [getFrameData, setCanvasData]);
+  }, [getFrameData, installFrameData]);
+
+  const navigateToFrameAtomically = useCallback(async (frameIndex: number): Promise<number> => {
+    const timeline = useTimelineStore.getState();
+    if (!Number.isInteger(frameIndex)) {
+      throw new Error('go_to_frame index must be an integer');
+    }
+    if (frameIndex < 0 || frameIndex >= timeline.config.durationFrames) {
+      throw new Error(
+        `go_to_frame index ${frameIndex} is out of range for ${timeline.config.durationFrames} timeline frames`,
+      );
+    }
+    if (isLoadingFrameRef.current) {
+      throw new Error('Frame synchronization is already in progress');
+    }
+
+    const requestedLayer = timeline.layers.find((layer) => layer.id === timeline.view.activeLayerId)
+      ?? timeline.layers[0];
+    if (!requestedLayer) {
+      throw new Error('go_to_frame requires an active layer');
+    }
+
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+
+    isLoadingFrameRef.current = true;
+    try {
+      const canvas = useCanvasStore.getState();
+      const installedLayerId = canvas.activeLayerId ?? lastActiveLayerIdRef.current;
+      const installedLayer = timeline.layers.find((layer) => layer.id === installedLayerId)
+        ?? requestedLayer;
+      const previousFrameIndex = lastFrameIndexRef.current;
+      const currentCells = commitPendingMove(new Map(cellsRef.current));
+      const previousContentFrame = getContentFrameAtTime(installedLayer, previousFrameIndex);
+      if (previousContentFrame) {
+        timeline.updateContentFrameData(
+          installedLayer.id,
+          previousContentFrame.id,
+          new Map(currentCells),
+        );
+      }
+
+      timeline.goToFrame(frameIndex);
+      const appliedTimeline = useTimelineStore.getState();
+      const confirmedFrameIndex = appliedTimeline.view.currentFrame;
+      if (confirmedFrameIndex !== frameIndex) {
+        throw new Error(
+          `go_to_frame applied frame ${confirmedFrameIndex} instead of requested frame ${frameIndex}`,
+        );
+      }
+
+      const appliedLayer = appliedTimeline.layers.find(
+        (layer) => layer.id === appliedTimeline.view.activeLayerId,
+      ) ?? appliedTimeline.layers[0];
+      if (!appliedLayer) {
+        throw new Error('go_to_frame target layer is unavailable');
+      }
+
+      const targetContentFrame = getContentFrameAtTime(appliedLayer, confirmedFrameIndex);
+      installFrameData(targetContentFrame?.data);
+      useCanvasStore.getState().setActiveLayerId(appliedLayer.id);
+      useCanvasStore.getState().setDirty(false);
+
+      lastFrameIndexRef.current = confirmedFrameIndex;
+      effectiveFrameIndexRef.current = confirmedFrameIndex;
+      lastActiveLayerIdRef.current = appliedLayer.id;
+      return confirmedFrameIndex;
+    } finally {
+      isLoadingFrameRef.current = false;
+    }
+  }, [commitPendingMove, installFrameData]);
+
+  useEffect(
+    () => registerAtomicFrameNavigator(navigateToFrameAtomically),
+    [navigateToFrameAtomically],
+  );
 
   // Handle frame switching
   useEffect(() => {
     const previousFrameIndex = lastFrameIndexRef.current;
     
     if (effectiveFrameIndex !== previousFrameIndex) {
-        // CRITICAL: Use the last known cells state, not current cells which may have already been updated
-      let currentCellsToSave = new Map(lastCellsRef.current);
-      
-      // Commit any pending move operations to the original frame before clearing state
-      if (moveStateParam && setMoveStateParam) {
-        const totalOffset = {
-          x: moveStateParam.baseOffset.x + moveStateParam.currentOffset.x,
-          y: moveStateParam.baseOffset.y + moveStateParam.currentOffset.y
-        };
-
-        // Create a new canvas data map with the moved cells
-        const newCells = new Map(cellsRef.current);
-
-        // Clear original positions
-        const originalKeys = moveStateParam.originalPositions ?? new Set(moveStateParam.originalData.keys());
-        originalKeys.forEach((key) => {
-          newCells.delete(key);
-        });
-
-        // Place cells at new positions AND build updated selection mask
-        const updatedSelectionMask = new Set<string>();
-        moveStateParam.originalData.forEach((cell, key) => {
-          const [origX, origY] = key.split(',').map(Number);
-          const newX = origX + totalOffset.x;
-          const newY = origY + totalOffset.y;
-          
-          // Only place if within bounds
-          if (newX >= 0 && newX < widthRef.current && newY >= 0 && newY < heightRef.current) {
-            newCells.set(`${newX},${newY}`, cell);
-            updatedSelectionMask.add(`${newX},${newY}`);
-          }
-        });
-        
-        // Also add any selected cells that weren't in originalData (empty cells in selection)
-        // We need to offset ALL selected cells, not just the ones with content
-        const toolStore = useToolStore.getState();
-        const activeSelection = toolStore.selection.active ? toolStore.selection.selectedCells 
-          : (toolStore.lassoSelection.active ? toolStore.lassoSelection.selectedCells 
-          : (toolStore.magicWandSelection.active ? toolStore.magicWandSelection.selectedCells : null));
-        
-        if (activeSelection) {
-          activeSelection.forEach((key) => {
-            const [origX, origY] = key.split(',').map(Number);
-            const newX = origX + totalOffset.x;
-            const newY = origY + totalOffset.y;
-            if (newX >= 0 && newX < widthRef.current && newY >= 0 && newY < heightRef.current) {
-              updatedSelectionMask.add(`${newX},${newY}`);
-            }
-          });
-        }
-
-        // Update the cells to save with the committed move
-        currentCellsToSave = newCells;
-        
-        // Update canvas data with committed move
-        setCanvasData(newCells);
-        
-        // Update selection positions to reflect the move
-        // IMPORTANT: Clear ALL tool selections first, then set current tool's selection
-        if (updatedSelectionMask.size > 0) {
-          const { activeTool } = toolStore;
-          
-          // Clear all tool selections first
-          toolStore.clearSelection();
-          toolStore.clearLassoSelection();
-          toolStore.clearMagicWandSelection();
-          
-          // Set the current tool's selection with updated positions
-          if (activeTool === 'select' || activeTool === 'lasso' || activeTool === 'magicwand') {
-            if (activeTool === 'select') {
-              toolStore.setSelectionFromMask(updatedSelectionMask);
-            } else if (activeTool === 'lasso') {
-              toolStore.setLassoSelectionFromMask(updatedSelectionMask, []);
-            } else if (activeTool === 'magicwand') {
-              toolStore.setMagicWandSelectionFromMask(updatedSelectionMask);
-            }
-          } else {
-            // If on a non-selection tool, default to rect selection
-            toolStore.setSelectionFromMask(updatedSelectionMask);
-          }
-          
-          // Update global selection store
-          useSelectionStore.getState().setSelection(updatedSelectionMask);
-        }
-        
-        // Clear move state after committing
-        setMoveStateParam(null);
-      }
+      // CRITICAL: Use the last known cells state, not current cells which may have already been updated
+      const currentCellsToSave = commitPendingMove(new Map(lastCellsRef.current));
       
       // PERSISTENT SELECTION: Selections now persist across frame changes
       // The selection coordinates remain the same - they represent a "region of interest"
@@ -307,7 +362,7 @@ export const useFrameSynchronization = (
       
       lastFrameIndexRef.current = effectiveFrameIndex;
     }
-  }, [effectiveFrameIndex, setFrameData, getFrameData, loadFrameToCanvas, isPlaying, isDraggingFrame, isDeletingFrame, isImportingSession, isProcessingHistory, moveStateParam, setMoveStateParam, setCanvasData]);
+  }, [effectiveFrameIndex, setFrameData, getFrameData, loadFrameToCanvas, isPlaying, isDraggingFrame, isDeletingFrame, isImportingSession, isProcessingHistory, commitPendingMove]);
 
   // PERF FIX: Auto-save via non-reactive Zustand subscribe() instead of useEffect([cells]).
   // This is THE most critical performance fix: previously, `cells` was a reactive dependency
@@ -315,7 +370,6 @@ export const useFrameSynchronization = (
   // value → every context consumer re-renders → entire CanvasGrid tree re-renders.
   // Now we watch for cells changes via a vanilla JS subscription that does NOT trigger
   // React re-renders of CanvasProvider.
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveCurrentCanvasToFrameRef = useRef(saveCurrentCanvasToFrame);
   saveCurrentCanvasToFrameRef.current = saveCurrentCanvasToFrame;
 

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -15,6 +15,7 @@ import { useTimelineStore } from '../stores/timelineStore';
 import { getContentFrameAtTime } from '../utils/layerCompositing';
 import { SessionImporter } from '../utils/sessionImporter';
 import { MCPCommandDispatcher } from './commandDispatcher';
+import { navigateToFrameAtomically } from './frameNavigation';
 import { useMCPStore } from './store';
 import type {
   MCPClientAuth,
@@ -975,8 +976,7 @@ export class MCPClient {
         break;
         
       case 'go_to_frame':
-        this.handleGoToFrame(command);
-        break;
+        return this.handleGoToFrame(command);
         
       case 'set_frame_duration':
         return this.handleSetFrameDuration(command);
@@ -1188,8 +1188,9 @@ export class MCPClient {
     useAnimationStore.getState().removeFrame(cmd.index);
   }
 
-  private handleGoToFrame(cmd: { index: number }): void {
-    useAnimationStore.getState().goToFrame(cmd.index);
+  private async handleGoToFrame(cmd: { index: number }): Promise<MCPCommandApplied> {
+    const currentFrameIndex = await navigateToFrameAtomically(cmd.index);
+    return { currentFrameIndex };
   }
 
   private handleSetFrameDuration(cmd: { index: number; duration: number }): MCPCommandApplied {

--- a/src/mcp/frameNavigation.ts
+++ b/src/mcp/frameNavigation.ts
@@ -1,0 +1,23 @@
+export type AtomicFrameNavigator = (frameIndex: number) => Promise<number>;
+
+let activeNavigator: AtomicFrameNavigator | null = null;
+
+export function registerAtomicFrameNavigator(
+  navigator: AtomicFrameNavigator,
+): () => void {
+  activeNavigator = navigator;
+
+  return () => {
+    if (activeNavigator === navigator) {
+      activeNavigator = null;
+    }
+  };
+}
+
+export function navigateToFrameAtomically(frameIndex: number): Promise<number> {
+  if (!activeNavigator) {
+    return Promise.reject(new Error('Frame synchronization is unavailable'));
+  }
+
+  return activeNavigator(frameIndex);
+}


### PR DESCRIPTION
## Summary
- add a hook-owned, awaitable frame navigation operation that flushes the installed canvas into its old content frame before moving the playhead
- install populated or empty target-frame data into `canvasStore` and advance synchronization refs before returning `applied.currentFrameIndex`
- reuse the serialized browser command dispatcher from #156 so immediately following current-frame batches cannot outrun navigation
- preserve explicit `set_cells_batch.frameIndex` active/background targeting

## Regression coverage
- flush / playhead / load / acknowledgement ordering
- populated and empty targets
- invalid indices and failure propagation
- pending layer switches
- variable-duration `go_to_frame(5)` immediately followed by a targetless mutation, with both acknowledgements reporting timeline frame 5 while content ordinal 1 is mutated

## Validation
- focused MCP/navigation tests (26 tests)
- adjacent synchronization suite (211 tests)
- targeted ESLint
- production build

Stacked on #156. Addresses #154.